### PR TITLE
Support GL_POLYGON

### DIFF
--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -2051,6 +2051,7 @@ static unsigned char draw_mode(GLenum mode)
         gxmode = GX_TRIANGLESTRIP;
         break;
     case GL_TRIANGLE_FAN:
+    case GL_POLYGON:
         gxmode = GX_TRIANGLEFAN;
         break;
     case GL_TRIANGLES:
@@ -2059,8 +2060,6 @@ static unsigned char draw_mode(GLenum mode)
     case GL_QUADS:
         gxmode = GX_QUADS;
         break;
-
-    case GL_POLYGON:
     default:
         return 0xff; // FIXME: Emulate these modes
     }


### PR DESCRIPTION
This can be trivially supported as a triangle fan, since polygons are guaranteed to be convex and the vertices are specified in the same order.
The difference will only be noticeable if the rendering mode is set to GL_LINE, in which case we we'll be producing more lines than needed: the real GL_POLYGON would draw just the perimeter, while we'll draw some internal lines too.