### PR TITLE
textures: allow binding textures with non generated names

### DIFF
--- a/src/texture.c
+++ b/src/texture.c
@@ -369,13 +369,15 @@ void glBindTexture(GLenum target, GLuint texture)
 
     HANDLE_CALL_LIST(BIND_TEXTURE, target, texture);
 
-    // If the texture has been initialized (data!=0) then load it to GX reg 0
-    if (TEXTURE_IS_RESERVED(texture_list[texture])) {
-        glparamstate.glcurtex = texture;
-
-        if (TEXTURE_IS_USED(texture_list[texture]))
-            GX_LoadTexObj(&texture_list[glparamstate.glcurtex].texobj, GX_TEXMAP0);
+    if (!TEXTURE_IS_RESERVED(texture_list[texture])) {
+        TEXTURE_RESERVE(texture_list[texture]);
     }
+
+    // If the texture has been initialized (data!=0) then load it to GX reg 0
+    glparamstate.glcurtex = texture;
+
+    if (TEXTURE_IS_USED(texture_list[texture]))
+        GX_LoadTexObj(&texture_list[glparamstate.glcurtex].texobj, GX_TEXMAP0);
 }
 
 void glDeleteTextures(GLsizei n, const GLuint *textures)


### PR DESCRIPTION
Calling glGenTextures() is not necessary in order to use a texture name: any number greater than 0 should work. So, drop the requirement for texture names to be reserved by glGenTextures(), and do the reservation in glBindTexture() itself, if needed.

This also means that we should rework our texture storage, and replace the array with a map. But let's leave that for the future.