### PR TITLE
lighting: do not multiply the material color with global ambient

### DIFF
--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -1841,7 +1841,7 @@ static void setup_render_stages(int texen)
 
                 if (glparamstate.lighting.color_material_mode == GL_AMBIENT ||
                     glparamstate.lighting.color_material_mode == GL_AMBIENT_AND_DIFFUSE) {
-                    acol = gxcol_cpy_mulfv(ccol, glparamstate.lighting.globalambient);
+                    acol = ccol;
                     ambient_set = true;
                 }
 


### PR DESCRIPTION
The global ambient is a property of the light and it's already accounted for in the ambient color register near the top of this method.

This multiplication was causing some elements in gl-117 to be way darker than they should be.