### PR TITLE
Fix stride computation for glDrawArray()

### DIFF
--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -1360,15 +1360,16 @@ void glEnableClientState(GLenum cap)
 
 void glVertexPointer(GLint size, GLenum type, GLsizei stride, const GLvoid *pointer)
 {
+    // TODO: support non float types
     glparamstate.vertex_array = (float *)pointer;
-    glparamstate.vertex_stride = stride;
+    glparamstate.vertex_stride = stride / sizeof(float);
     if (stride == 0)
         glparamstate.vertex_stride = size;
 }
 void glNormalPointer(GLenum type, GLsizei stride, const GLvoid *pointer)
 {
     glparamstate.normal_array = (float *)pointer;
-    glparamstate.normal_stride = stride;
+    glparamstate.normal_stride = stride / sizeof(float);
     if (stride == 0)
         glparamstate.normal_stride = 3;
 }
@@ -1377,7 +1378,7 @@ void glColorPointer(GLint size, GLenum type,
                     GLsizei stride, const GLvoid *pointer)
 {
     glparamstate.color_array = (float *)pointer;
-    glparamstate.color_stride = stride;
+    glparamstate.color_stride = stride / sizeof(float);
     if (stride == 0)
         glparamstate.color_stride = size;
 }
@@ -1385,7 +1386,7 @@ void glColorPointer(GLint size, GLenum type,
 void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const GLvoid *pointer)
 {
     glparamstate.texcoord_array = (float *)pointer;
-    glparamstate.texcoord_stride = stride;
+    glparamstate.texcoord_stride = stride / sizeof(float);
     if (stride == 0)
         glparamstate.texcoord_stride = size;
 }


### PR DESCRIPTION
The stride passed by the client is in bytes, while the current implementation stores the stride as the number of floats to skip. So, we need to divide the value passed by the client by sizeof(float).

Note that there a couple of big issues with the current implementation, that will need to be fixed:
- the `type` parameter is ignored, we always assume that the client passes floats.
- the stride value is assumed to be a multiple of 4 (`sizeof(float)`), whereas the client could pass any value.