### PR TITLE
debug: allow toggling individual debug features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include(GNUInstallDirs)
 add_library(${TARGET} STATIC
     src/call_lists.c
     src/call_lists.h
+    src/debug.c
     src/debug.h
     src/gc_gl.c
     src/image_DXT.c

--- a/src/call_lists.c
+++ b/src/call_lists.c
@@ -335,7 +335,8 @@ bool _ogx_call_list_append(CommandType op, ...)
     va_list ap;
     int count;
 
-    debug("Adding command %d to list %d", op, glparamstate.current_call_list.index);
+    debug(OGX_LOG_CALL_LISTS, "Adding command %d to list %d",
+          op, glparamstate.current_call_list.index);
     int index = last_command(&buffer);
     if (index >= 0) {
         command = &buffer->commands[index];
@@ -551,7 +552,7 @@ void glCallList(GLuint id)
 
     HANDLE_CALL_LIST(CALL_LIST, id);
 
-    debug("Calling list %d", id - CALL_LIST_START_ID);
+    debug(OGX_LOG_CALL_LISTS, "Calling list %d", id - CALL_LIST_START_ID);
 
     bool must_decrement = false;
     if (glparamstate.current_call_list.index >= 0) {

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -186,10 +186,7 @@ int ogx_prepare_swap_buffers()
 
 void ogx_initialize()
 {
-    const char *log_env = getenv("OPENGX_DEBUG");
-    if (log_env) {
-        _ogx_log_level = log_env[0] - '0';
-    }
+    _ogx_log_init();
 
     glparamstate.current_call_list.index = -1;
     GX_SetDispCopyGamma(GX_GM_1_0);
@@ -1728,7 +1725,8 @@ static LightMasks prepare_lighting()
             masks.specular_mask |= (1 << gx_specular_idx);
         }
     }
-    debug("Ambient mask 0x%02x, diffuse 0x%02x, specular 0x%02x",
+    debug(OGX_LOG_LIGHTING,
+          "Ambient mask 0x%02x, diffuse 0x%02x, specular 0x%02x",
           masks.ambient_mask, masks.diffuse_mask, masks.specular_mask);
     return masks;
 }

--- a/src/pixels.cpp
+++ b/src/pixels.cpp
@@ -562,6 +562,10 @@ void _ogx_bytes_to_texture(const void *data, GLenum format, GLenum type,
         }
     }
 
+    debug(OGX_LOG_TEXTURE,
+          "No fast conversion registered for GL format %04x to GX format %d",
+          format, gx_format);
+
     /* Here starts the code for the generic converter. We start by selecting
      * the proper Texel subclass for the given GX texture format, then we
      * select the reader based on the GL type parameter, and then we do the


### PR DESCRIPTION
Enabling all debugging messages can potentially produce a lot of output, which makes debugging possibly harder. One is typically interested in debugging a specific feature of OpenGL; enable this by allowing the command line variable to specify on which features debugging must be enabled. For example:

    OPENGX_DEBUG=lighthing,texture