### PR TITLE
texture: support generation of texture coordinates

### DIFF
--- a/src/state.h
+++ b/src/state.h
@@ -52,12 +52,23 @@ typedef struct gltexture_
     GXTexObj texobj;
 } gltexture_;
 
+typedef enum {
+    OGX_TEXGEN_S = 1 << 0,
+    OGX_TEXGEN_T = 1 << 1,
+    OGX_TEXGEN_R = 1 << 2,
+    OGX_TEXGEN_Q = 1 << 3,
+} OgxTexgenMask;
+
 typedef struct glparams_
 {
     Mtx44 modelview_matrix;
     Mtx44 projection_matrix;
     Mtx44 modelview_stack[MAX_MODV_STACK];
     Mtx44 projection_stack[MAX_PROJ_STACK];
+    float texture_eye_plane_s[4];
+    float texture_eye_plane_t[4];
+    float texture_object_plane_s[4];
+    float texture_object_plane_t[4];
     int cur_modv_mat, cur_proj_mat;
 
     unsigned char srcblend, dstblend;
@@ -66,6 +77,10 @@ typedef struct glparams_
     unsigned char matrixmode;
     unsigned char frontcw, cullenabled;
     uint16_t texture_env_mode;
+    /* There should be 4 of these (for S, T, R, Q) but GX uses a single
+     * transformation for all of them */
+    uint16_t texture_gen_mode;
+    OgxTexgenMask texture_gen_enabled;
     GLenum glcullmode;
     int glcurtex;
     GXColor clear_color;
@@ -108,6 +123,7 @@ typedef struct glparams_
             unsigned dirty_lighting : 1;
             unsigned dirty_material : 1;
             unsigned dirty_cull : 1;
+            unsigned dirty_texture_gen : 1;
         } bits;
         unsigned int all;
     } dirty;

--- a/src/texture.c
+++ b/src/texture.c
@@ -160,6 +160,46 @@ void glTexParameteri(GLenum target, GLenum pname, GLint param)
     };
 }
 
+void glTexGeni(GLenum coord, GLenum pname, GLint param)
+{
+    /* Since in GX we cannot set different modes per texture coordinate, we
+     * only look at the S coordinate, hoping that the other enabled coordinates
+     * will use the same parameters. */
+    if (coord != GL_S) return;
+
+    switch (pname) {
+    case GL_TEXTURE_GEN_MODE:
+        glparamstate.texture_gen_mode = param;
+        glparamstate.dirty.bits.dirty_texture_gen = 1;
+        break;
+    }
+}
+
+void glTexGenfv(GLenum coord, GLenum pname, const GLfloat *params)
+{
+    switch (pname) {
+    case GL_TEXTURE_GEN_MODE:
+        glTexGeni(coord, pname, params[0]);
+        break;
+    case GL_EYE_PLANE:
+        if (coord == GL_S) {
+            floatcpy(glparamstate.texture_eye_plane_s, params, 4);
+        } else if (coord == GL_T) {
+            floatcpy(glparamstate.texture_eye_plane_t, params, 4);
+        }
+        glparamstate.dirty.bits.dirty_texture_gen = 1;
+        break;
+    case GL_OBJECT_PLANE:
+        if (coord == GL_S) {
+            floatcpy(glparamstate.texture_object_plane_s, params, 4);
+        } else if (coord == GL_T) {
+            floatcpy(glparamstate.texture_object_plane_t, params, 4);
+        }
+        glparamstate.dirty.bits.dirty_texture_gen = 1;
+        break;
+    }
+}
+
 void glTexEnvf(GLenum target, GLenum pname, GLfloat param)
 {
     /* For the time being, all the parameters we support take integer values */

--- a/src/utils.h
+++ b/src/utils.h
@@ -203,4 +203,21 @@ static inline int read_index(const GLvoid *indices, GLenum type, int i)
     }
 }
 
+static inline void set_gx_mtx_rowv(int row, Mtx m, float *values)
+{
+    m[row][0] = values[0];
+    m[row][1] = values[1];
+    m[row][2] = values[2];
+    m[row][3] = values[3];
+}
+
+static inline void set_gx_mtx_row(int row, Mtx m,
+                                  float c0, float c1, float c2, float c3)
+{
+    m[row][0] = c0;
+    m[row][1] = c1;
+    m[row][2] = c2;
+    m[row][3] = c3;
+}
+
 #endif /* OGX_UTILS_H */


### PR DESCRIPTION
For the time being support is limited to the GL_EYE_LINEAR and GL_OBJECT_LINEAR modes, and to S and T coordinates. Also, due to limitation of the GX API, the same generation mode is applied to both coordinates (that is, the actual setting on the T coordinate is ignored, and the one from S is used on T too).