### PR TITLE
build: disable RTTI and exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(OpenGX VERSION 0.1)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
 
 set(TARGET opengx)
 


### PR DESCRIPTION
The C++ files that we have in our project (at the moment it's only pixels.cpp) are by default compiled with RTTI information, which causes the resulting object file to require libstdc++ (because of symbols like _ZTVN10__cxxabiv117__class_type_infoE). This dependency is then required by any project linking opengx, even if they are pure C projects.

Since we are not actually using RTTI, let's disable it. We also disable exceptions, not because they are causing any trouble, but simply because we don't need them.