### PR TITLE
debug: use SYS_Report instead of fprintf()

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -32,8 +32,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef OGX_DEBUG_H
 #define OGX_DEBUG_H
 
+#include <ogc/system.h>
 #include <errno.h>
-#include <stdio.h>
 
 typedef enum {
     OGX_LOG_WARNING = 1 << 0,
@@ -47,12 +47,12 @@ extern OgxLogMask _ogx_log_mask;
 /* Warning are always emitted unless the mask is 0 */
 #define warning(format, ...) \
     if (_ogx_log_mask) { \
-        fprintf(stderr, format "\n", ##__VA_ARGS__); \
+        SYS_Report(format "\n", ##__VA_ARGS__); \
     }
 
 #define debug(mask, format, ...) \
     if (_ogx_log_mask & mask) { \
-        fprintf(stderr, format "\n", ##__VA_ARGS__); \
+        SYS_Report(format "\n", ##__VA_ARGS__); \
     }
 
 void _ogx_log_init();


### PR DESCRIPTION
Dolphin does a mediocre job at intercepting printf and fprintf calls, failing when there are no additional parameters after the format string: those lines are not captured.

Use SYS_Report(), which besides being more appropriate, does not suffer from the same issue.