### PR TITLE
Stencil test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ add_library(${TARGET} STATIC
     src/call_lists.h
     src/debug.c
     src/debug.h
+    src/efb.c
+    src/efb.h
     src/functions.c
     src/gc_gl.c
     src/image_DXT.c
@@ -34,6 +36,8 @@ add_library(${TARGET} STATIC
     src/pixels.h
     src/selection.c
     src/state.h
+    src/stencil.c
+    src/stencil.h
     src/texture.c
     src/utils.h
 )

--- a/doc/src/opengx.tex
+++ b/doc/src/opengx.tex
@@ -417,6 +417,62 @@ Call lists are mostly implemented in software, storing the command opcodes and p
 The HANDLE\_CALL\_LIST macro is called at the beginning of those GL functions that can be stored into a call list. It takes care of adding the operation to the active call list (if there's one) minimizing the visual impact of call lists on the code base.
 
 
+\subsection {Stencil test}
+
+The stencil test allows to discard individual fragments depending on the outcome of a comparison between the value stored in the stencil buffer for that fragment and a reference value. The compared values can also be masked with a bitmask before comparison, and the generation of the stencil buffer involves drawing primitives and performing logical and arithmetical operations on the drawn stencil pixels. The stencil test is typically used to render shadows and reflections. Unfortunately, nor the GameCube hardware or the GX APIs provide any support for the stencil test, so we have to emulate it, partially in software, partially with an additional TEV stage.
+
+\subsubsection {Discarding fragments}
+
+Let's first see how opengx discards fragments which don't pass the stencil test; for the time being, let's assume that we have managed to build a stencil buffer (in opengx it can be 4 or 8 bits wide, with 4 being the default) and focus only on how to build a TEV stage which does the comparison and discards the fragment. We will be setting up the TEV stage to operate in \emph{compare mode}, where the inputs are combined according to this formula:
+
+    $$ output = d + ((a OP b) ? c : 0 $$
+
+and $OP$ will be either “equal” (\lstinline{GX_TEV_COMP_A8_EQ}) or “greater than” (\lstinline{GX_TEV_COMP_A8_GT}). Our goal is to decide whether a fragment will be drawn or not, so we'll be using the alpha channel as the output, set $d$ to zero and $c$ to the alpha from the previous stage: in this way, depending on the result of the comparison $a OP b$ (we'll see how to set $a$ and $b$ later below), we can control whether display the fragment with its original alpha, or not display it at all.
+
+Note that we'll have to make the Z buffer operate per fragment and not per vertex (by setting \lstinline{GX_SetZCompLoc(GX_DISABLE)}) and set the alpha compare function (\fname{GX\_SetAlphaCompare}) to exclude all fragments having an alpha value of zero: this is important so that the discarded fragments won't update the Z-buffer.
+
+The next problem we have to solve is setting up a texture coordinate generation that, once the stencil texture is loaded in our TEV stage, would allow us to read its pixels using screen coordinates; in other words, we want to make it so that for every fragment processed in this stage, its texel would coincide with a screen pixel. This can be achieved by setting up a texture coordinate generation matrix that multiplies the primitive's vector's \emph{position} and transforms that to the exact x and y coordinates that this vertex will occupy on the screen. Such a matrix can be built by concatenating the movel-view matrix with the projection matrix, but we must take into account that such a matrix will transform vertex coordinates into the \lstinline{[-1,1]x[-1,1]} range whereas the TEV expects texture coordinates to be in the \lstinline{[0,1]x[0,1]} range, so we have to concatenate an additional matrix to translate and scale the coordinates by half.
+
+Another issue is how to actually implement the comparison, since the OpenGL specification supports all kinds of arithmetical comparisons, whereas the TEV only supports comparing for equality (\lstinline{GX_TEV_COMP_A8_EQ}) and strict "greater than" (\lstinline{GX_TEV_COMP_A8_GT}); however, since we know that we are operating on integer values, most of this operations can be emulated by inverting the order of the operands in the TEV, or by altering the reference value by ±1, as shown in Figure~\ref{table:stencil1}.
+
+\begin{figure}[ht]
+\centering
+
+\begin{tabular}{|l|l|l|}
+\hline
+    {GL comparison} & {Formula} & {GX comparison} \\
+\hline
+    GL\_EQUAL & $a = b$ & $a = b$ \\
+\hline
+	GL\_GREATER & $a > b$ & $a > b$\\
+\hline
+	GL\_LESS & $a < b$ & $b > a$\\
+\hline
+	GL\_GEQUAL & $a \geq b$ & $a > b - 1$ \\
+\hline
+	GL\_LEQUAL & $a \leq b$ & $b + 1 > a$ \\
+\hline
+\end{tabular}
+\caption{Mapping OpenGL stencil comparisons into the TEV. $a$ is the value from the stencil texture, and $b$ is the reference value}
+\label{table:stencil1}
+\end {figure}
+
+What is missing from that figure is the comparison for not equality (\lstinline{GL_NOTEQUAL}), which simply cannot be implemented using the comparisons provided by the TEV engine. For that reason, if the comparison mode is \lstinline{GL_NOTEQUAL}, opengx builds a special stencil texture in software, whose pixels are set to 1 if the stencil buffer value is different from reference value and 0 otherwise, and then uses the \lstinline{GX_TEV_COMP_A8_GT} (greater than) comparison on this texture's pixels.
+
+Note that while building the stencil texture in software sounds like a non optimal decision (and indeed it is), opengx has to do it in any case, even for those comparisons from Figure~\ref{table:stencil1} supported by the TEV, in order to support the masking step described in the OpenGL specification: that is, OpenGL is not directly comparing the stencil buffer value with the reference value, but both values are \emph{bitwise AND'ed} with a bitmask given by the programmer. This means that before drawing a primitive on which the stencil test must run, opengx will read the stencil buffer and generate a stencil texture that can be used with the comparisons described above. Using the \fname{GX\_ReadBoundingBox} function allows us to minimize the work by updating only the area that changed.
+
+\subsubsection {Drawing the stencil buffer}
+
+When drawing to the stencil buffer, special care must be taken to avoid making this drawing visible, so before performing a stencil draw operation opengx saves the current contents of the EFB to a texture, then loads the previous contents of the stencil buffer into the EFB, perform the stencil rendering, then saves the EFB to the stencil buffer and finally restores the previous contents of the EFB (the ones containing the visible graphics). This is clearly not optimal when the sequence of drawing operations to the screen is intertwined with drawing operations to the stencil buffer (as is often the case), but unfortunately there's no way around this. We could still use the \fname{GX\_ReadBoundingBox} function to keep track of the areas that need saving and restoring, so there might be some room for optimization here.
+
+OpenGL specifies several logical and arithmetical operations that can be applied when rendering to the stencil buffer, with the most used being by far \lstinline{GL_KEEP} and \lstinline{GL_REPLACE}: the former is trivial to implement, since it just means that no drawing must happen on the stencil buffer; the latter is used to replace the stencil buffer's value with the reference value, so this is also not hard to realize by rendering the primitive with no lighting, no texturing, and just fixing the drawing color to the reference value. The \lstinline{GL_ZERO} operation is also easy to implement, being a special case of \lstinline{GL_REPLACE} where instead of using the reference colour we just draw total black. Other operations are not currently implemented (see the \ref{sec:stencillimitations} section for details).
+
+\subsubsection {Limitations}
+\label{sec:stencillimitations}
+
+The stencil drawing operations \lstinline{GL_INCR}, \lstinline{GL_DECR}, \lstinline{GL_INCR_WRAP}, \lstinline{GL_DECR_WRAP} and \lstinline{GL_INVERT} are not implemented. It might be possible that at least some of them could be implemented in the hardware by setting an appropriate blending mode. Another posibility is to make these functions not directly render on the stencil buffer, but on yet another offscreen buffer, and then process the results in software. But none of these solutions have been implemented so far, given how rarely these operations are used (at least in public source code indexed by GitHub).
+
+
 \subsection {Selection mode}
 
 GL selection mode, also known as "picking mode", is typically used in applications to determine which objects are rendered at a certain screen position, in order to implement mouse interactions. When selection mode is active, drawing primitives do not result in any pixels (or even Z-pixels) being drawn, but instead produce a stack containing the names of the object which would have been drawn.

--- a/src/debug.c
+++ b/src/debug.c
@@ -43,6 +43,7 @@ static const struct {
     { "call-lists", OGX_LOG_CALL_LISTS },
     { "lighting", OGX_LOG_LIGHTING },
     { "texture", OGX_LOG_TEXTURE },
+    { "stencil", OGX_LOG_STENCIL },
     { NULL, 0 },
 };
 

--- a/src/efb.c
+++ b/src/efb.c
@@ -1,0 +1,152 @@
+/*****************************************************************************
+Copyright (c) 2011  David Guillen Fandos (david@davidgf.net)
+Copyright (c) 2024  Alberto Mardegan (mardy@users.sourceforge.net)
+All rights reserved.
+
+Attention! Contains pieces of code from others such as Mesa and GRRLib
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL COPYRIGHT HOLDERS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "efb.h"
+
+#include "debug.h"
+#include "state.h"
+#include "utils.h"
+
+#include <GL/gl.h>
+#include <malloc.h>
+
+OgxEfbContentType _ogx_efb_content_type = OGX_EFB_SCENE;
+
+static GXTexObj s_efb_texture;
+/* This is the ID of the drawing operation that was copied last (0 = none) */
+static int s_draw_count_copied = 0;
+
+void _ogx_efb_save(OgxEfbFlags flags)
+{
+    /* TODO: support saving Z-buffer (code in selection.c) */
+
+    if (s_draw_count_copied == glparamstate.draw_count) {
+        printf("Not copying EFB\n");
+        /* We already copied this frame, nothing to do here */
+        return;
+    }
+
+    s_draw_count_copied = glparamstate.draw_count;
+
+    u16 width = glparamstate.viewport[2];
+    u16 height = glparamstate.viewport[3];
+    u16 oldwidth = GX_GetTexObjWidth(&s_efb_texture);
+    u16 oldheight = GX_GetTexObjHeight(&s_efb_texture);
+    uint8_t *texels = GX_GetTexObjData(&s_efb_texture);
+    if (texels) {
+        texels = MEM_PHYSICAL_TO_K0(texels);
+    }
+
+    if (width != oldwidth || height != oldheight) {
+        if (texels) {
+            free(texels);
+        }
+        u32 size = GX_GetTexBufferSize(width, height, GX_TF_RGBA8, 0, GX_FALSE);
+        texels = memalign(32, size);
+        DCInvalidateRange(texels, size);
+
+        GX_InitTexObj(&s_efb_texture, texels, width, height,
+                      GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+        GX_InitTexObjLOD(&s_efb_texture, GX_NEAR, GX_NEAR,
+                         0.0f, 0.0f, 0.0f, 0, 0, GX_ANISO_1);
+    }
+
+    _ogx_efb_save_to_buffer(GX_TF_RGBA8, width, height, texels, flags);
+}
+
+void _ogx_efb_restore(OgxEfbFlags flags)
+{
+    /* TODO: support restoring Z-buffer (code in selection.c) */
+
+    _ogx_efb_restore_texobj(&s_efb_texture);
+}
+
+void _ogx_efb_save_to_buffer(uint8_t format, uint16_t width, uint16_t height,
+                             void *texels, OgxEfbFlags flags)
+{
+    GX_SetCopyFilter(GX_FALSE, NULL, GX_FALSE, NULL);
+    GX_SetTexCopySrc(glparamstate.viewport[0],
+                     glparamstate.viewport[1],
+                     width,
+                     height);
+    GX_SetTexCopyDst(width, height, format, GX_FALSE);
+    GX_CopyTex(texels, flags & OGX_EFB_CLEAR ? GX_TRUE : GX_FALSE);
+    /* TODO: check if all of these sync functions are needed */
+    GX_PixModeSync();
+    GX_SetDrawDone();
+    u32 size = GX_GetTexBufferSize(width, height, format, 0, GX_FALSE);
+    DCInvalidateRange(texels, size);
+    GX_WaitDrawDone();
+}
+
+void _ogx_efb_restore_texobj(GXTexObj *texobj)
+{
+    _ogx_setup_2D_projection();
+    u16 width = GX_GetTexObjWidth(texobj);
+    u16 height = GX_GetTexObjHeight(texobj);
+    GX_LoadTexObj(texobj, GX_TEXMAP0);
+
+    GX_ClearVtxDesc();
+    GX_SetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GX_SetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+    GX_SetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XY, GX_U16, 0);
+    GX_SetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_U8, 0);
+    GX_SetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY);
+    GX_SetNumTexGens(1);
+    GX_SetNumTevStages(1);
+    GX_SetNumChans(0);
+    GX_SetTevOp(GX_TEVSTAGE0, GX_REPLACE);
+    GX_SetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLORNULL);
+
+    GX_SetCullMode(GX_CULL_NONE);
+    glparamstate.dirty.bits.dirty_cull = 1;
+
+    GX_SetZMode(GX_FALSE, GX_ALWAYS, GX_FALSE);
+    glparamstate.dirty.bits.dirty_z = 1;
+
+    GX_SetBlendMode(GX_BM_NONE, GX_BL_ZERO, GX_BL_ZERO, GX_LO_COPY);
+    glparamstate.dirty.bits.dirty_blend = 1;
+
+    GX_SetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    glparamstate.dirty.bits.dirty_alphatest = 1;
+
+    GX_Begin(GX_QUADS, GX_VTXFMT0, 4);
+    GX_Position2u16(0, 0);
+    GX_TexCoord2u8(0, 0);
+    GX_Position2u16(0, height);
+    GX_TexCoord2u8(0, 1);
+    GX_Position2u16(width, height);
+    GX_TexCoord2u8(1, 1);
+    GX_Position2u16(width, 0);
+    GX_TexCoord2u8(1, 0);
+    GX_End();
+}

--- a/src/efb.c
+++ b/src/efb.c
@@ -139,6 +139,9 @@ void _ogx_efb_restore_texobj(GXTexObj *texobj)
     GX_SetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
     glparamstate.dirty.bits.dirty_alphatest = 1;
 
+    GX_SetColorUpdate(GX_TRUE);
+    glparamstate.dirty.bits.dirty_color_update = 1;
+
     GX_Begin(GX_QUADS, GX_VTXFMT0, 4);
     GX_Position2u16(0, 0);
     GX_TexCoord2u8(0, 0);

--- a/src/efb.h
+++ b/src/efb.h
@@ -1,5 +1,6 @@
 /*****************************************************************************
 Copyright (c) 2011  David Guillen Fandos (david@davidgf.net)
+Copyright (c) 2024  Alberto Mardegan (mardy@users.sourceforge.net)
 All rights reserved.
 
 Attention! Contains pieces of code from others such as Mesa and GRRLib
@@ -29,34 +30,32 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#ifndef OGX_DEBUG_H
-#define OGX_DEBUG_H
+#ifndef OPENGX_EFB_H
+#define OPENGX_EFB_H
 
-#include <ogc/system.h>
-#include <errno.h>
-#include <stdio.h>
+#include <GL/gl.h>
+#include <malloc.h>
+#include <ogc/gx.h>
 
 typedef enum {
-    OGX_LOG_WARNING = 1 << 0,
-    OGX_LOG_CALL_LISTS = 1 << 1,
-    OGX_LOG_LIGHTING = 1 << 2,
-    OGX_LOG_TEXTURE = 1 << 3,
-    OGX_LOG_STENCIL = 1 << 4,
-} OgxLogMask;
+    OGX_EFB_NONE = 0,
+    OGX_EFB_CLEAR = 1 << 0,
+    OGX_EFB_COLOR = 1 << 1,
+    OGX_EFB_ZBUFFER = 1 << 2,
+} OgxEfbFlags;
 
-extern OgxLogMask _ogx_log_mask;
+typedef enum {
+    OGX_EFB_SCENE = 1,
+    OGX_EFB_STENCIL,
+} OgxEfbContentType;
 
-/* Warning are always emitted unless the mask is 0 */
-#define warning(format, ...) \
-    if (_ogx_log_mask) { \
-        SYS_Report(format "\n", ##__VA_ARGS__); \
-    }
+extern OgxEfbContentType _ogx_efb_content_type;
 
-#define debug(mask, format, ...) \
-    if (_ogx_log_mask & mask) { \
-        SYS_Report(format "\n", ##__VA_ARGS__); \
-    }
+void _ogx_efb_save(OgxEfbFlags flags);
+void _ogx_efb_restore(OgxEfbFlags flags);
 
-void _ogx_log_init();
+void _ogx_efb_save_to_buffer(uint8_t format, uint16_t width, uint16_t height,
+                             void *texels, OgxEfbFlags flags);
+void _ogx_efb_restore_texobj(GXTexObj *texobj);
 
-#endif /* OGX_DEBUG_H */
+#endif /* OPENGX_EFB_H */

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -50,6 +50,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "opengx.h"
 #include "selection.h"
 #include "state.h"
+#include "stencil.h"
 #include "utils.h"
 
 #include <GL/gl.h>
@@ -338,7 +339,18 @@ void ogx_initialize()
     glparamstate.fog.start = 0.0f;
     glparamstate.fog.end = 1.0f;
 
+    glparamstate.stencil.enabled = false;
+    glparamstate.stencil.func = GX_ALWAYS;
+    glparamstate.stencil.ref = 0;
+    glparamstate.stencil.mask = 0xff;
+    glparamstate.stencil.wmask = 0xff;
+    glparamstate.stencil.clear = 0;
+    glparamstate.stencil.op_fail = GL_KEEP;
+    glparamstate.stencil.op_zfail = GL_KEEP;
+    glparamstate.stencil.op_zpass = GL_KEEP;
+
     glparamstate.error = GL_NO_ERROR;
+    glparamstate.draw_count = 0;
 
     // Setup data types for every possible attribute
 
@@ -378,6 +390,14 @@ void _ogx_setup_2D_projection()
     GX_LoadProjectionMtx(proj, GX_ORTHOGRAPHIC);
 
     glparamstate.dirty.bits.dirty_matrices = 1;
+}
+
+void _ogx_setup_3D_projection()
+{
+    /* Assume that the modelview matrix has already been updated to GX_PNMTX3
+     */
+    GX_SetCurrentMtx(GX_PNMTX3);
+    PROJECTION_UPDATE
 }
 
 void glEnable(GLenum cap)
@@ -422,6 +442,9 @@ void glEnable(GLenum cap)
     case GL_DEPTH_TEST:
         glparamstate.ztest = GX_TRUE;
         glparamstate.dirty.bits.dirty_z = 1;
+        break;
+    case GL_STENCIL_TEST:
+        _ogx_stencil_enabled();
         break;
     case GL_FOG:
         glparamstate.fog.enabled = 1;
@@ -484,6 +507,9 @@ void glDisable(GLenum cap)
     case GL_DEPTH_TEST:
         glparamstate.ztest = GX_FALSE;
         glparamstate.dirty.bits.dirty_z = 1;
+        break;
+    case GL_STENCIL_TEST:
+        _ogx_stencil_disabled();
         break;
     case GL_LIGHTING:
         glparamstate.lighting.enabled = 0;
@@ -779,6 +805,7 @@ void glViewport(GLint x, GLint y, GLsizei width, GLsizei height)
     glparamstate.viewport[3] = height;
     GX_SetViewport(x, y, width, height, 0.0f, 1.0f);
     GX_SetScissor(x, y, width, height);
+    _ogx_stencil_update();
 }
 
 void glScissor(GLint x, GLint y, GLsizei width, GLsizei height)
@@ -1155,6 +1182,10 @@ void glClear(GLbitfield mask)
         return;
     }
 
+    if (mask & GL_STENCIL_BUFFER_BIT) {
+        _ogx_stencil_clear();
+    }
+
     if (mask & GL_DEPTH_BUFFER_BIT) {
         GX_SetZMode(GX_TRUE, GX_ALWAYS, GX_TRUE);
         GX_SetZCompLoc(GX_DISABLE);
@@ -1237,6 +1268,8 @@ void glClear(GLbitfield mask)
     glparamstate.dirty.bits.dirty_matrices = 1;
     glparamstate.dirty.bits.dirty_cull = 1;
     glparamstate.dirty.bits.dirty_texture_gen = 1;
+
+    glparamstate.draw_count++;
 }
 
 void glDepthFunc(GLenum func)
@@ -1971,17 +2004,18 @@ static void setup_texture_stage(u8 stage, u8 raster_color, u8 raster_alpha,
     }
 }
 
-static void setup_render_stages(int texen)
+bool _ogx_setup_render_stages()
 {
+    int stages = 0, tex_coords = 0, tex_maps = 0;
+
     if (glparamstate.lighting.enabled) {
         LightMasks light_mask = prepare_lighting();
 
         GXColor color_zero = { 0, 0, 0, 0 };
         GXColor color_gamb = gxcol_new_fv(glparamstate.lighting.globalambient);
 
+        stages = 2;
         GX_SetNumChans(2);
-        GX_SetNumTevStages(2);
-        GX_SetNumTexGens(0);
 
         unsigned char vert_color_src = GX_SRC_VTX;
         if (!glparamstate.cs.color_enabled || !glparamstate.lighting.color_material_enabled) {
@@ -2070,10 +2104,12 @@ static void setup_render_stages(int texen)
         // Select COLOR1A1 for the rasterizer, disable all textures
         GX_SetTevOrder(GX_TEVSTAGE1, GX_TEXCOORDNULL, GX_TEXMAP_DISABLE, GX_COLOR1A1);
 
-        if (texen) {
+        if (glparamstate.texture_enabled) {
             // Do not select any raster value, Texture 0 for texture rasterizer and TEXCOORD0 slot for tex coordinates
             setup_texture_stage(GX_TEVSTAGE2, GX_CC_CPREV, GX_CA_APREV, GX_COLORNULL);
-            GX_SetNumTevStages(3);
+            stages++;
+            tex_coords++;
+            tex_maps++;
         }
     } else {
         // Unlit scene
@@ -2087,30 +2123,29 @@ static void setup_render_stages(int texen)
         unsigned char rasterized_color = GX_COLOR0A0;
         if (!glparamstate.cs.color_enabled) { // No need for vertex color raster, it's constant
             // Use constant color
-            vertex_color_register = GX_CC_KONST;
-            vertex_alpha_register = GX_CA_KONST;
-            // Select register 0 for color/alpha
-            GX_SetTevKColorSel(GX_TEVSTAGE0, GX_TEV_KCSEL_K0);
-            GX_SetTevKAlphaSel(GX_TEVSTAGE0, GX_TEV_KASEL_K0_A);
+            vertex_color_register = GX_CC_C0;
+            vertex_alpha_register = GX_CA_A0;
             // Load the color (current GL color)
             GXColor ccol = gxcol_new_fv(glparamstate.imm_mode.current_color);
-            GX_SetTevKColor(GX_KCOLOR0, ccol);
+            GX_SetTevColor(GX_TEVREG0, ccol);
 
             rasterized_color = GX_COLORNULL; // Disable vertex color rasterizer
         }
 
+        stages = 1;
         GX_SetNumChans(1);
-        GX_SetNumTevStages(1);
 
         // Disable lighting and output vertex color to the rasterized color
         GX_SetChanCtrl(GX_COLOR0A0, GX_DISABLE, GX_SRC_REG, GX_SRC_VTX, 0, 0, 0);
         GX_SetChanCtrl(GX_COLOR1A1, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, 0, 0, 0);
 
-        if (texen) {
+        if (glparamstate.texture_enabled) {
             // Select COLOR0A0 for the rasterizer, Texture 0 for texture rasterizer and TEXCOORD0 slot for tex coordinates
             setup_texture_stage(GX_TEVSTAGE0,
                                 vertex_color_register, vertex_alpha_register,
                                 rasterized_color);
+            tex_coords++;
+            tex_maps++;
         } else {
             // In data: d: Raster Color
             GX_SetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, vertex_color_register);
@@ -2120,17 +2155,23 @@ static void setup_render_stages(int texen)
             GX_SetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
             // Select COLOR0A0 for the rasterizer, Texture 0 for texture rasterizer and TEXCOORD0 slot for tex coordinates
             GX_SetTevOrder(GX_TEVSTAGE0, GX_TEXCOORDNULL, GX_TEXMAP_DISABLE, rasterized_color);
-            GX_SetNumTexGens(0);
         }
     }
 
+    if (glparamstate.stencil.enabled) {
+        bool should_draw =
+            _ogx_stencil_setup_tev(&stages, &tex_coords, tex_maps);
+        if (!should_draw) return false;
+    }
+    GX_SetNumTevStages(stages);
+    GX_SetNumTexGens(tex_coords);
+
     setup_fog();
+    return true;
 }
 
 void _ogx_apply_state()
 {
-    setup_render_stages(glparamstate.texture_enabled);
-
     // Set up the OGL state to GX state
     if (glparamstate.dirty.bits.dirty_z)
         GX_SetZMode(glparamstate.ztest, glparamstate.zfunc, glparamstate.zwrite & glparamstate.ztest);
@@ -2146,15 +2187,23 @@ void _ogx_apply_state()
             GX_SetBlendMode(GX_BM_NONE, glparamstate.srcblend, glparamstate.dstblend, GX_LO_CLEAR);
     }
 
-    if (glparamstate.dirty.bits.dirty_alphatest) {
+    if (glparamstate.dirty.bits.dirty_alphatest ||
+        glparamstate.dirty.bits.dirty_stencil) {
+        u8 params[4] = { GX_ALWAYS, 0, GX_ALWAYS, 0 };
+        int comparisons = 0;
         if (glparamstate.alphatest_enabled) {
-            GX_SetZCompLoc(GX_DISABLE);
-            GX_SetAlphaCompare(glparamstate.alpha_func, glparamstate.alpha_ref,
-                               GX_AOP_AND, GX_ALWAYS, 0);
-        } else {
-            GX_SetZCompLoc(GX_ENABLE);
-            GX_SetAlphaCompare(GX_ALWAYS, 0, GX_AOP_AND, GX_ALWAYS, 0);
+            params[0] = glparamstate.alpha_func;
+            params[1] = glparamstate.alpha_ref;
+            comparisons++;
         }
+        if (glparamstate.stencil.enabled) {
+            params[comparisons * 2] = GX_GREATER;
+            /* The reference value is initialized to 0, which is the value we
+             * want */
+            comparisons++;
+        }
+        GX_SetZCompLoc(comparisons > 0 ? GX_DISABLE : GX_ENABLE);
+        GX_SetAlphaCompare(params[0], params[1], GX_AOP_AND, params[2], params[3]);
     }
 
     if (glparamstate.dirty.bits.dirty_cull) {
@@ -2171,80 +2220,46 @@ void _ogx_apply_state()
     }
 
     /* Reset the updated bits to 0. We don't unconditionally reset everything
-     * to 0 because some states might still be dirty. */
+     * to 0 because some states might still be dirty: for example, the stencil
+     * checks alters the texture coordinate generation. */
     glparamstate.dirty.bits.dirty_cull = 0;
     glparamstate.dirty.bits.dirty_lighting = 0;
     glparamstate.dirty.bits.dirty_matrices = 0;
+    glparamstate.dirty.bits.dirty_stencil = 0;
     glparamstate.dirty.bits.dirty_alphatest = 0;
     glparamstate.dirty.bits.dirty_blend = 0;
     glparamstate.dirty.bits.dirty_color_update = 0;
     glparamstate.dirty.bits.dirty_z = 0;
 }
 
-void glDrawArrays(GLenum mode, GLint first, GLsizei count)
+typedef struct {
+    u8 gxmode;
+    GLint first;
+    GLsizei count;
+} OgxDrawData;
+
+static void flat_draw_geometry(void *cb_data)
 {
-    unsigned char gxmode = draw_mode(mode);
-    if (gxmode == 0xff)
-        return;
+    OgxDrawData *data = cb_data;
 
-    int texen = glparamstate.cs.texcoord_enabled;
-    if (glparamstate.current_call_list.index >= 0 &&
-        glparamstate.current_call_list.execution_depth == 0) {
-        _ogx_call_list_append(COMMAND_GXLIST);
-    } else {
-        _ogx_apply_state();
-        /* When not building a display list, we can optimize the drawing by
-         * avoiding passing texture coordinates if texturing is not enabled.
-         */
-        texen = texen && glparamstate.texture_enabled;
-    }
-
-    int color_provide = 0;
-    if (glparamstate.cs.color_enabled &&
-        (!glparamstate.lighting.enabled || glparamstate.lighting.color_material_enabled)) { // Vertex colouring
-        if (glparamstate.lighting.enabled)
-            color_provide = 2; // Lighting requires two color channels
-        else
-            color_provide = 1;
-    }
-
-    draw_arrays_general(gxmode, first, count, glparamstate.cs.normal_enabled,
-                        color_provide, texen);
+    /* TODO: we could use C++ templates here too, to build more effective
+     * drawing functions that only process the data we need. */
+    draw_arrays_general(data->gxmode, data->first, data->count,
+                        false, /* no normals */
+                        false, /* no color */
+                        false /* no texturing */);
+    GX_End();
 }
 
-void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indices)
+static void draw_elements_general(uint8_t gxmode, int count, GLenum type,
+                                  const GLvoid *indices,
+                                  int ne, int color_provide, int texen)
 {
-
-    unsigned char gxmode = draw_mode(mode);
-    if (gxmode == 0xff)
-        return;
-
-    int texen = glparamstate.cs.texcoord_enabled;
-    if (glparamstate.current_call_list.index >= 0 &&
-        glparamstate.current_call_list.execution_depth == 0) {
-        _ogx_call_list_append(COMMAND_GXLIST);
-    } else {
-        _ogx_apply_state();
-        /* When not building a display list, we can optimize the drawing by
-         * avoiding passing texture coordinates if texturing is not enabled.
-         */
-        texen = texen && glparamstate.texture_enabled;
-    }
-
-    int color_provide = 0;
-    if (glparamstate.cs.color_enabled &&
-        (!glparamstate.lighting.enabled || glparamstate.lighting.color_material_enabled)) { // Vertex colouring
-        if (glparamstate.lighting.enabled)
-            color_provide = 2; // Lighting requires two color channels
-        else
-            color_provide = 1;
-    }
-
     // Not using indices
     GX_ClearVtxDesc();
     if (glparamstate.cs.vertex_enabled)
         GX_SetVtxDesc(GX_VA_POS, GX_DIRECT);
-    if (glparamstate.cs.normal_enabled)
+    if (ne)
         GX_SetVtxDesc(GX_VA_NRM, GX_DIRECT);
     if (color_provide)
         GX_SetVtxDesc(GX_VA_CLR0, GX_DIRECT);
@@ -2263,17 +2278,16 @@ void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indic
     // Invalidate vertex data as may have been modified by the user
     GX_InvVtxCache();
 
-    bool loop = (mode == GL_LINE_LOOP);
+    bool loop = (gxmode == GL_LINE_LOOP);
     GX_Begin(gxmode, GX_VTXFMT0, count + loop);
-    int i;
-    for (i = 0; i < count + loop; i++) {
+    for (int i = 0; i < count + loop; i++) {
         int index = read_index(indices, type, i % count);
         float value[4];
         _ogx_array_reader_read_float(&glparamstate.vertex_array, index, value);
 
         GX_Position3f32(value[0], value[1], value[2]);
 
-        if (glparamstate.cs.normal_enabled) {
+        if (ne) {
             _ogx_array_reader_read_float(&glparamstate.normal_array, index, value);
             GX_Normal3f32(value[0], value[1], value[2]);
         }
@@ -2292,6 +2306,110 @@ void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indic
         }
     }
     GX_End();
+}
+
+typedef struct {
+    u8 gxmode;
+    GLsizei count;
+    GLenum type;
+    const GLvoid *indices;
+} OgxDrawElementsData;
+
+static void flat_draw_elements(void *cb_data)
+{
+    OgxDrawElementsData *data = cb_data;
+
+    /* TODO: we could use C++ templates here too, to build more effective
+     * drawing functions that only process the data we need. */
+    draw_elements_general(data->gxmode, data->count, data->type, data->indices,
+                          false, /* no normals */
+                          false, /* no color */
+                          false /* no texturing */);
+    GX_End();
+}
+
+void glDrawArrays(GLenum mode, GLint first, GLsizei count)
+{
+    unsigned char gxmode = draw_mode(mode);
+    if (gxmode == 0xff)
+        return;
+
+    bool should_draw = true;
+    int texen = glparamstate.cs.texcoord_enabled;
+    if (glparamstate.current_call_list.index >= 0 &&
+        glparamstate.current_call_list.execution_depth == 0) {
+        _ogx_call_list_append(COMMAND_GXLIST);
+    } else {
+        should_draw = _ogx_setup_render_stages();
+        _ogx_apply_state();
+
+        /* When not building a display list, we can optimize the drawing by
+         * avoiding passing texture coordinates if texturing is not enabled.
+         */
+        texen = texen && glparamstate.texture_enabled;
+    }
+
+    if (should_draw) {
+        int color_provide = 0;
+        if (glparamstate.cs.color_enabled &&
+            (!glparamstate.lighting.enabled || glparamstate.lighting.color_material_enabled)) { // Vertex colouring
+            if (glparamstate.lighting.enabled)
+                color_provide = 2; // Lighting requires two color channels
+            else
+                color_provide = 1;
+        }
+
+        draw_arrays_general(gxmode, first, count, glparamstate.cs.normal_enabled,
+                            color_provide, texen);
+        glparamstate.draw_count++;
+    }
+
+    if (glparamstate.stencil.enabled) {
+        OgxDrawData draw_data = { gxmode, first, count };
+        _ogx_stencil_draw(flat_draw_geometry, &draw_data);
+    }
+}
+
+void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indices)
+{
+
+    unsigned char gxmode = draw_mode(mode);
+    if (gxmode == 0xff)
+        return;
+
+    bool should_draw = true;
+    int texen = glparamstate.cs.texcoord_enabled;
+    if (glparamstate.current_call_list.index >= 0 &&
+        glparamstate.current_call_list.execution_depth == 0) {
+        _ogx_call_list_append(COMMAND_GXLIST);
+    } else {
+        should_draw = _ogx_setup_render_stages();
+        _ogx_apply_state();
+        /* When not building a display list, we can optimize the drawing by
+         * avoiding passing texture coordinates if texturing is not enabled.
+         */
+        texen = texen && glparamstate.texture_enabled;
+    }
+
+    if (should_draw) {
+        int color_provide = 0;
+        if (glparamstate.cs.color_enabled &&
+            (!glparamstate.lighting.enabled || glparamstate.lighting.color_material_enabled)) { // Vertex colouring
+            if (glparamstate.lighting.enabled)
+                color_provide = 2; // Lighting requires two color channels
+            else
+                color_provide = 1;
+        }
+
+        draw_elements_general(gxmode, count, type, indices,
+                              glparamstate.cs.normal_enabled, color_provide, texen);
+        glparamstate.draw_count++;
+    }
+
+    if (glparamstate.stencil.enabled) {
+        OgxDrawElementsData draw_data = { gxmode, count, type, indices };
+        _ogx_stencil_draw(flat_draw_elements, &draw_data);
+    }
 }
 
 static void draw_arrays_general(uint8_t gxmode, int first, int count, int ne,
@@ -2411,8 +2529,6 @@ void glOrtho(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdou
 // NOT GOING TO IMPLEMENT
 
 void glBlendEquation(GLenum mode) {}
-void glClearStencil(GLint s) {}
-void glStencilMask(GLuint mask) {} // Should use Alpha testing to achieve similar results
 void glShadeModel(GLenum mode) {}  // In theory we don't have GX equivalent?
 void glHint(GLenum target, GLenum mode) {}
 

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -2340,6 +2340,11 @@ void glDrawArrays(GLenum mode, GLint first, GLsizei count)
         glparamstate.current_call_list.execution_depth == 0) {
         _ogx_call_list_append(COMMAND_GXLIST);
     } else {
+        if (glparamstate.stencil.enabled) {
+            OgxDrawData draw_data = { gxmode, first, count };
+            _ogx_stencil_draw(flat_draw_geometry, &draw_data);
+        }
+
         should_draw = _ogx_setup_render_stages();
         _ogx_apply_state();
 
@@ -2363,11 +2368,6 @@ void glDrawArrays(GLenum mode, GLint first, GLsizei count)
                             color_provide, texen);
         glparamstate.draw_count++;
     }
-
-    if (glparamstate.stencil.enabled) {
-        OgxDrawData draw_data = { gxmode, first, count };
-        _ogx_stencil_draw(flat_draw_geometry, &draw_data);
-    }
 }
 
 void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indices)
@@ -2383,6 +2383,11 @@ void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indic
         glparamstate.current_call_list.execution_depth == 0) {
         _ogx_call_list_append(COMMAND_GXLIST);
     } else {
+        if (glparamstate.stencil.enabled) {
+            OgxDrawElementsData draw_data = { gxmode, count, type, indices };
+            _ogx_stencil_draw(flat_draw_elements, &draw_data);
+        }
+
         should_draw = _ogx_setup_render_stages();
         _ogx_apply_state();
         /* When not building a display list, we can optimize the drawing by
@@ -2404,11 +2409,6 @@ void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indic
         draw_elements_general(gxmode, count, type, indices,
                               glparamstate.cs.normal_enabled, color_provide, texen);
         glparamstate.draw_count++;
-    }
-
-    if (glparamstate.stencil.enabled) {
-        OgxDrawElementsData draw_data = { gxmode, count, type, indices };
-        _ogx_stencil_draw(flat_draw_elements, &draw_data);
     }
 }
 

--- a/src/opengx.h
+++ b/src/opengx.h
@@ -82,6 +82,16 @@ extern uintptr_t ogx_fast_conv_LA_IA8;
 extern uintptr_t ogx_fast_conv_Intensity_I8;
 extern uintptr_t ogx_fast_conv_Alpha_A8;
 
+typedef enum {
+    OGX_STENCIL_NONE = 0,
+    /* Don't worry about Z buffer being updated even if a fragment fails the
+     * stencil test. */
+    OGX_STENCIL_DIRTY_Z = 1 << 0,
+    OGX_STENCIL_8BIT = 1 << 1,
+} OgxStencilFlags;
+
+void ogx_stencil_create(OgxStencilFlags flags);
+
 #ifdef __cplusplus
 } // extern C
 #endif

--- a/src/state.h
+++ b/src/state.h
@@ -36,6 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <GL/gl.h>
 #include <gccore.h>
+#include <stdbool.h>
 
 // Constant definition. Here are the limits of this implementation.
 // Can be changed with care.
@@ -91,6 +92,7 @@ typedef struct glparams_
     GLenum glcullmode;
     GLenum render_mode;
     int glcurtex;
+    int draw_count;
     GXColor clear_color;
     float clearz;
 
@@ -157,6 +159,7 @@ typedef struct glparams_
             unsigned dirty_material : 1;
             unsigned dirty_cull : 1;
             unsigned dirty_texture_gen : 1;
+            unsigned dirty_stencil : 1;
         } bits;
         unsigned int all;
     } dirty;
@@ -203,6 +206,18 @@ typedef struct glparams_
         float start;
         float end;
     } fog;
+
+    struct _stencil {
+        bool enabled;
+        uint8_t func;
+        uint8_t ref;
+        uint8_t mask;
+        uint8_t wmask;
+        uint8_t clear;
+        uint16_t op_fail;
+        uint16_t op_zfail;
+        uint16_t op_zpass;
+    } stencil;
 
     gltexture_ textures[_MAX_GL_TEX];
 

--- a/src/stencil.c
+++ b/src/stencil.c
@@ -1,0 +1,676 @@
+/*****************************************************************************
+Copyright (c) 2011  David Guillen Fandos (david@davidgf.net)
+Copyright (c) 2024  Alberto Mardegan (mardy@users.sourceforge.net)
+All rights reserved.
+
+Attention! Contains pieces of code from others such as Mesa and GRRLib
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL COPYRIGHT HOLDERS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "stencil.h"
+
+#include "debug.h"
+#include "efb.h"
+#include "opengx.h"
+#include "state.h"
+#include "utils.h"
+
+#include <GL/gl.h>
+#include <malloc.h>
+
+static bool s_wants_stencil = false;
+static bool s_stencil_texture_needs_update = false;
+static uint8_t s_stencil_format = GX_CTF_R4;
+static OgxStencilFlags s_stencil_flags = OGX_STENCIL_NONE;
+/* This is the authoritative stencil buffer contents: note that the order of
+ * the pixel data follows the GX texture scrambling logic. */
+static uint8_t *s_stencil_buffer = NULL;
+/* This is a simplified version of the stencil buffer only used for drawing:
+ * its pixels are set to 0 for blocked areas and > 0 for paintable areas. */
+static GXTexObj s_stencil_texture;
+static struct _dirty_area {
+    uint16_t top;
+    uint16_t bottom;
+    uint16_t left;
+    uint16_t right;
+} s_dirty_area = { 0, 0, 0, 0 };
+
+static void check_bounding_box()
+{
+    /* Read the new bounding box and update the old one, if needed */
+    struct _dirty_area a;
+    GX_ReadBoundingBox(&a.top, &a.bottom, &a.left, &a.right);
+    if (a.bottom <= a.top || a.right <= a.left) return;
+
+    if (s_dirty_area.top >= s_dirty_area.bottom) {
+        /* previous area is invalid, use the new one */
+        s_dirty_area = a;
+    } else {
+        /* enlarge the area */
+        if (a.top < s_dirty_area.top) s_dirty_area.top = a.top;
+        if (a.left < s_dirty_area.left) s_dirty_area.left = a.left;
+        if (a.bottom > s_dirty_area.bottom) s_dirty_area.bottom = a.bottom;
+        if (a.right > s_dirty_area.right) s_dirty_area.right = a.right;
+    }
+    debug(OGX_LOG_STENCIL, "Bounding box (%d,%d) - (%d,%d)",
+          s_dirty_area.left, s_dirty_area.top, s_dirty_area.right, s_dirty_area.bottom);
+}
+
+static inline u8 invert_comp(u8 comp)
+{
+    switch (comp) {
+    case GX_NEVER: return GX_ALWAYS;
+    case GX_LESS: return GX_GEQUAL;
+    case GX_EQUAL: return GX_NEQUAL;
+    case GX_LEQUAL: return GX_GREATER;
+    case GX_GREATER: return GX_LEQUAL;
+    case GX_GEQUAL: return GX_LESS;
+    case GX_ALWAYS: return GX_NEVER;
+    default: return 0xff;
+    }
+}
+
+/* The type of comparison we'll setup in the TEV, and, accordingly, the stencil
+ * texture texel to prepare.
+ */
+typedef enum {
+    TEV_COMP_ALWAYS,        /* stencil TEV stage not needed, always drawing */
+    TEV_COMP_NEVER,         /* stencil TEV stage not needed, not drawing */
+    TEV_COMP_DIRECT,        /* TEV stage will use a HW comparison, the stencil
+                               texture can be prepared with the masked stencil
+                               buffer data */
+    TEV_COMP_IND_NEQUAL,    /* the TEV does not support the GL_NOTEQUAL
+                               comparison, so we'll need to build a stencil
+                               texture having 1 where the stencil test passes,
+                               and 0 otherwise */
+} TevComparisonType;
+
+static inline TevComparisonType comparison_type(uint8_t comparison, uint8_t masked_ref)
+{
+    switch (comparison) {
+    case GX_ALWAYS:
+        return TEV_COMP_ALWAYS;
+    case GX_NEVER:
+        return TEV_COMP_NEVER;
+    case GX_NEQUAL:
+        return TEV_COMP_IND_NEQUAL;
+    default: /* All other types */
+        /* Handle a few special cases that lead to optimizations */
+        if (comparison == GX_GEQUAL && masked_ref == 0)
+            return TEV_COMP_ALWAYS;
+        if (comparison == GX_LEQUAL) {
+            uint8_t max_value = s_stencil_flags & OGX_STENCIL_8BIT ? 0xff : 0xf;
+            if (masked_ref == max_value)
+                return TEV_COMP_ALWAYS;
+        }
+        return TEV_COMP_DIRECT;
+    }
+}
+
+static inline bool tev_stage_needed(TevComparisonType comp_type)
+{
+    return comp_type != TEV_COMP_ALWAYS && comp_type != TEV_COMP_NEVER;
+}
+
+/* Prepare the texture used for stencil test: we cannot use the stencil buffer
+ * directly, because the TEV does lack a function for bitwise AND of the pixels
+ * (which is needed to implement the OpenGL stencil "mask" operation) and does
+ * not support the full set of pixel comparisons used in OpenGL (it supports
+ * only EQ (=) and GT (>) comparisons).
+ * For this reason, we prepare a texture whose pixel data is a transformed
+ * version of the stencil buffer which can be used with the TEV operations.
+ * Depending on the value of the OpenGL stencil comparison function, we might
+ * need to rebuild this texture differently.
+ */
+static void update_stencil_texture()
+{
+    if (!s_stencil_texture_needs_update) return;
+    s_stencil_texture_needs_update = false;
+
+    u16 top, bottom, left, right;
+    top = s_dirty_area.top;
+    bottom = s_dirty_area.bottom;
+    left = s_dirty_area.left;
+    right = s_dirty_area.right;
+    if (bottom <= top || right <= left) return;
+
+    u16 width = GX_GetTexObjWidth(&s_stencil_texture);
+    u16 height = GX_GetTexObjHeight(&s_stencil_texture);
+    u32 size = GX_GetTexBufferSize(width, height, s_stencil_format, 0, GX_FALSE);
+
+    /* The bounding box can have a 1 pixel error (returning a slightly bigger
+     * area) and, in addition to that, we round up to the texture blocks, to
+     * simplify the loops */
+    int block_width = 8;
+    int block_height = s_stencil_flags & OGX_STENCIL_8BIT ? 4 : 8;
+    int block_pitch = width / block_width;
+
+    int block_start_y = top / block_height;
+    int block_end_y = (bottom + block_height - 1) / block_height;
+    int block_start_x = left / block_width;
+    int block_end_x = (right + block_width - 1) / block_width;
+    int width_blocks = block_end_x - block_start_x;
+
+    void *stencil_data = s_stencil_buffer;
+    void *stencil_texels =
+        MEM_PHYSICAL_TO_K0(GX_GetTexObjData(&s_stencil_texture));
+    uint8_t masked_ref = glparamstate.stencil.ref & glparamstate.stencil.mask;
+    TevComparisonType comp_type = comparison_type(glparamstate.stencil.func,
+                                                  masked_ref);
+    if (comp_type == TEV_COMP_DIRECT) {
+        debug(OGX_LOG_STENCIL,
+              "Updating stencil texture for direct comparison");
+        /* Fast conversion: we build a texture whose pixels are the stencil
+         * buffer values ANDed with the stencil mask. Such a texture can be
+         * used with most comparison functions. */
+        uint32_t mask = glparamstate.stencil.mask;
+        if (!(s_stencil_flags & OGX_STENCIL_8BIT)) {
+            mask |= mask << 4; /* replicate the nibble it to fill a byte */
+        }
+        /* replicate the byte to fill a 32-bit word */
+        mask |= mask << 8;
+        mask |= mask << 16;
+        for (int y = block_start_y; y < block_end_y; y++) {
+            int offset = (y * block_pitch + block_start_x) * 32;
+            uint32_t *src = stencil_data + offset;
+            uint32_t *dst = stencil_texels + offset;
+            /* A block is 32 bytes, which we fill with 32-bit integers */
+            for (int i = 0; i < width_blocks * 32 / sizeof(uint32_t); i++) {
+                *dst++ = *src++ & mask;
+            }
+            //DCStoreRange(stencil_texels + offset, width_blocks * 32);
+        }
+    } else if (comp_type == TEV_COMP_IND_NEQUAL) {
+        debug(OGX_LOG_STENCIL,
+              "Updating stencil texture for NEQUAL comparison");
+        /* These's just no way to implement the GL_NOTEQUAL comparison on the
+         * TEV, so we prepare a stencil texture that already contains the
+         * result of the compasiron. */
+        uint8_t mask = glparamstate.stencil.mask;
+        for (int y = block_start_y; y < block_end_y; y++) {
+            int offset = (y * block_pitch + block_start_x) * 32;
+            uint8_t *src = stencil_data + offset;
+            uint8_t *dst = stencil_texels + offset;
+            /* A block is 32 bytes */
+            for (int i = 0; i < width_blocks * 32; i++) {
+                if (s_stencil_flags & OGX_STENCIL_8BIT) {
+                    uint8_t gequal_than_ref = (*src++ & mask) != masked_ref;
+                    *dst++ = gequal_than_ref;
+                } else {
+                    /* Two pixels per byte */
+                    uint8_t gequal_than_ref0 = (*src++ & mask) != masked_ref;
+                    uint8_t gequal_than_ref1 = ((*src++ >> 4) & mask) != masked_ref;
+                    *dst++ = gequal_than_ref0 | (gequal_than_ref1 << 4);
+                }
+            }
+        }
+    }
+    DCStoreRange(stencil_texels, size); // FIXME
+    GX_InvalidateTexAll();
+
+    /* The area is not dirty anymore */
+    memset(&s_dirty_area, 0, sizeof(s_dirty_area));
+}
+
+static void load_stencil_into_efb()
+{
+    GXTexObj texture;
+
+    /* The stencil texture object has been created on initialization, get the
+     * size from it. */
+    u16 width = GX_GetTexObjWidth(&s_stencil_texture);
+    u16 height = GX_GetTexObjHeight(&s_stencil_texture);
+
+    GX_InitTexObj(&texture, s_stencil_buffer, width, height,
+                  s_stencil_format, GX_CLAMP, GX_CLAMP, GX_FALSE);
+    GX_InitTexObjLOD(&texture, GX_NEAR, GX_NEAR,
+                     0.0f, 0.0f, 0.0f, 0, 0, GX_ANISO_1);
+    GX_InvalidateTexAll();
+    _ogx_efb_restore_texobj(&texture);
+
+    _ogx_efb_content_type = OGX_EFB_STENCIL;
+}
+
+static bool setup_tev_full(int *stages, int *tex_coords, int tex_maps,
+                           bool invert_logic)
+{
+    u8 stage = GX_TEVSTAGE0 + *stages;
+    u8 tex_coord = GX_TEXCOORD0 + *tex_coords;
+    u8 tex_map = GX_TEXMAP0 + tex_maps;
+
+    /* TODO: keep track of the potential values of the stencil buffer, and
+     * avoid drawing if we are sure that a match cannot happen. */
+    uint8_t masked_ref = glparamstate.stencil.ref & glparamstate.stencil.mask;
+    uint8_t comp_func = invert_logic ?
+        invert_comp(glparamstate.stencil.func) : glparamstate.stencil.func;
+    TevComparisonType comp_type = comparison_type(comp_func, masked_ref);
+    if (!tev_stage_needed(comp_type)) {
+        warning("TEV stage not needed");
+        return comp_type == TEV_COMP_ALWAYS;
+    }
+
+    debug(OGX_LOG_STENCIL, "%d TEV stages, %d tex_coords, %d tex_maps",
+          *stages, *tex_coords, tex_maps);
+    u8 logical_op;
+    u8 ref_value = GX_CA_KONST;
+    bool invert_operands = false;
+    switch (comp_func) {
+    case GX_EQUAL:
+        logical_op = GX_TEV_COMP_A8_EQ;
+        break;
+    case GX_GREATER:
+        invert_operands = true;
+        // fallthrough
+    case GX_LESS:
+        logical_op = GX_TEV_COMP_A8_GT;
+        break;
+    case GX_LEQUAL:
+        logical_op = GX_TEV_COMP_A8_GT;
+        masked_ref += 1; /* because a<=b <=> b+1>a, when a and b are ints */
+        break;
+    case GX_GEQUAL:
+        logical_op = GX_TEV_COMP_A8_GT;
+        invert_operands = true;
+        masked_ref -= 1; /* because a>=b <=> a>b-1, when a and b are ints */
+        break;
+    case GX_NEQUAL:
+        ref_value = GX_CA_ZERO;
+        logical_op = GX_TEV_COMP_A8_GT;
+        break;
+    default:
+        warning(" ########## Unhandled stencil comparison: %d\n", glparamstate.stencil.func);
+    }
+
+    debug(OGX_LOG_STENCIL, "masked ref = %d, logical op = %d, invert = %d",
+          masked_ref, logical_op, invert_operands);
+    if (ref_value == GX_CA_KONST) {
+        GX_SetTevKColorSel(stage, GX_TEV_KCSEL_K0);
+        GX_SetTevKAlphaSel(stage, GX_TEV_KASEL_K0_A);
+        if (!(s_stencil_flags & OGX_STENCIL_8BIT)) {
+            /* Replicate the value in the upper 4 bits */
+            masked_ref |= masked_ref << 4;
+        }
+        GXColor ref_color = { 0, 0, 0, masked_ref};
+        GX_SetTevKColor(GX_KCOLOR0, ref_color);
+    }
+
+    /* Set a TEV stage that draws only where the stencil texture is > 0 */
+    GX_SetTevColorIn(stage, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_CPREV);
+    GX_SetTevColorOp(stage, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+    /* Set a logical operation: output = d + ((a OP b) ? c:0) */
+    if (!invert_operands) {
+        GX_SetTevAlphaIn(stage, GX_CA_TEXA, ref_value, GX_CA_APREV, GX_CA_ZERO);
+    } else {
+        GX_SetTevAlphaIn(stage, ref_value, GX_CA_TEXA, GX_CA_APREV, GX_CA_ZERO);
+    }
+    GX_SetTevAlphaOp(stage, logical_op, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+    GX_SetTevOrder(stage, tex_coord, tex_map, GX_COLORNULL);
+
+    update_stencil_texture();
+
+    /* Add a set of texture coordinates that exactly match the viewport
+     * coordinates of each vertex. This is done by multiplying the vertex
+     * positions by the model view matrix and by the projection matrix. */
+    Mtx m;
+    guMtxScaleApply(glparamstate.modelview_matrix, m,
+                    glparamstate.projection_matrix[0][0],
+                    glparamstate.projection_matrix[1][1],
+                    1.0);
+    /* This matrix scales the [-1,1]x[-1,1] viewport to [0,1]x[0,1]. I have no
+     * idea how and why it works, but it does! */
+    const static Mtx trans = {
+        {-0.5,   0, 0.5, 0},
+        {0,    0.5, 0.5, 0},
+        {0,      0,   1, 0},
+    };
+    guMtxConcat(trans, m, m);
+    GX_LoadTexMtxImm(m, GX_TEXMTX0, GX_MTX3x4);
+
+    GX_SetTexCoordGen(tex_coord, GX_TG_MTX3x4, GX_TG_POS, GX_TEXMTX0);
+    glparamstate.dirty.bits.dirty_texture_gen = 1;
+
+    GX_LoadTexObj(&s_stencil_texture, tex_map);
+    ++(*stages);
+    ++(*tex_coords);
+    return true;
+}
+
+static bool draw_op(uint16_t op,
+                    bool check_stencil, bool invert_stencil,
+                    bool check_z, bool invert_z,
+                    OgxStencilDrawCallback callback, void *cb_data)
+{
+    if (op == GL_KEEP) {
+        /* nothing to do */
+        return false;
+    }
+
+    int num_stages = 1;
+    int num_tex_coords = 0;
+
+    uint8_t masked_ref = glparamstate.stencil.ref & glparamstate.stencil.wmask;
+    if (!(s_stencil_flags &OGX_STENCIL_8BIT)) {
+        /* Replicate the nibble to fill the whole byte */
+        masked_ref |= masked_ref << 4;
+    }
+    GXColor refColor = {
+        masked_ref,
+        masked_ref,
+        masked_ref,
+        255
+    };
+
+    GXColor drawColor;
+    if (op == GL_REPLACE) {
+        drawColor = refColor;
+    } else if (op == GL_ZERO) {
+        drawColor.r = drawColor.g = drawColor.b = 0;
+        drawColor.a = 255;
+    } else {
+        /* TODO: either find a blend mode to implement the desired effect
+         * (this is probably possible for the GL_INCR and GL_DECR
+         * operations, but note that then we'd need to move the stencil check
+         * to a TEV stage in order to make the blending operation available for
+         * them), or render to an intermediate buffer and then manually update
+         * the stencil buffer pixel by pixel (use a bounding box to reduce the
+         * area). */
+        warning("Stencil operation %04x not implemented");
+        drawColor = refColor;
+    }
+
+    /* We set the dirty bit below, after loading the stencil buffer into the
+     * EFB, because otherwise the call to _ogx_apply_state() would reset it
+     * again. */
+    GX_SetColorUpdate(GX_TRUE);
+
+    if (_ogx_efb_content_type == OGX_EFB_SCENE) {
+        debug(OGX_LOG_STENCIL, "Saving scene EFB, clearing, loading stencil");
+
+        GXColor black = { 0, 0, 0, 255 };
+        GX_SetCopyClear(black, GX_MAX_Z24);
+        GX_DrawDone();
+        _ogx_efb_save(OGX_EFB_COLOR);
+
+        load_stencil_into_efb();
+        /* We clear the bounding box because at the end of the drawing
+         * operations on the stencil buffer we will need to update the stencil
+         * texture which we use for the actual drawing, and the bounding box
+         * allows us to do it more efficiently. */
+        GX_DrawDone();
+        GX_ClearBoundingBox();
+        _ogx_setup_3D_projection();
+
+        /* TODO: restoring the EFB we alter the cull mode, Z mode, alpha
+         * compare and more. All these settings need to be restored. */
+        _ogx_apply_state();
+    }
+
+    glparamstate.dirty.bits.dirty_color_update = 1;
+
+    u8 stage = GX_TEVSTAGE0;
+    GX_SetTevColor(GX_TEVREG0, drawColor);
+    GX_SetTevOrder(stage, GX_TEXCOORDNULL, GX_TEXMAP_DISABLE, GX_COLOR0A0);
+    /* Pass the constant color */
+    GX_SetTevColorIn(stage, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_C0);
+    GX_SetTevAlphaIn(stage, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GX_SetTevColorOp(stage, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1,
+                     GX_TRUE, GX_TEVPREV);
+    GX_SetTevAlphaOp(stage, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1,
+                     GX_TRUE, GX_TEVPREV);
+    GX_SetNumChans(1);
+
+    GX_SetChanCtrl(GX_COLOR0A0, GX_DISABLE, GX_SRC_VTX, GX_SRC_VTX, 0, GX_DF_NONE, GX_AF_NONE);
+    if (check_stencil) {
+        bool must_draw =
+            setup_tev_full(&num_stages, &num_tex_coords, 0, invert_stencil);
+        if (!must_draw) return false;
+    }
+
+    s_stencil_texture_needs_update = true;
+
+    GX_SetNumTexGens(num_tex_coords);
+    GX_SetNumTevStages(num_stages);
+
+    if (check_z) {
+        /* Use the Z-buffer, but don't modify it! */
+        u8 comp = invert_z ?
+            invert_comp(glparamstate.zfunc) : glparamstate.zfunc;
+        GX_SetZMode(GX_TRUE, comp, GX_FALSE);
+    } else {
+        GX_SetZMode(GX_FALSE, GX_ALWAYS, GX_FALSE);
+    }
+    glparamstate.dirty.bits.dirty_z = 1;
+
+    GX_SetBlendMode(GX_BM_NONE, GX_BL_ZERO, GX_BL_ZERO, GX_LO_COPY);
+    glparamstate.dirty.bits.dirty_blend = 1;
+
+    /* Draw */
+    callback(cb_data);
+    return true;
+}
+
+bool _ogx_stencil_setup_tev(int *stages, int *tex_coords, int tex_maps)
+{
+    return setup_tev_full(stages, tex_coords, tex_maps, false);
+}
+
+void _ogx_stencil_draw(OgxStencilDrawCallback callback, void *cb_data)
+{
+    /* If all of op_fail, op_zpass and op_zfail are the same, we can use a
+     * single draw operation to update the stencil buffer, since it would
+     * happen unconditionally */
+    bool single_op =
+        (glparamstate.stencil.op_fail == glparamstate.stencil.op_zpass &&
+         glparamstate.stencil.op_zpass == glparamstate.stencil.op_zfail &&
+         glparamstate.stencil.op_zfail == glparamstate.stencil.op_fail);
+    bool check_stencil, invert_stencil, check_z, invert_z;
+    if (single_op) {
+        check_stencil = false;
+        invert_stencil = false;
+        check_z = false;
+        invert_z = false;
+        draw_op(glparamstate.stencil.op_fail,
+                check_stencil, invert_stencil, check_z, invert_z,
+                callback, cb_data);
+    } else {
+        /* Perform the three operations separately */
+        check_stencil = true;
+        invert_stencil = true;
+        check_z = false;
+        invert_z = false;
+        draw_op(glparamstate.stencil.op_fail,
+                check_stencil, invert_stencil, check_z, invert_z,
+                callback, cb_data);
+
+        invert_stencil = false;
+        check_z = true;
+        draw_op(glparamstate.stencil.op_zpass,
+                check_stencil, invert_stencil, check_z, invert_z,
+                callback, cb_data);
+
+        invert_z = true;
+        draw_op(glparamstate.stencil.op_zfail,
+                check_stencil, invert_stencil, check_z, invert_z,
+                callback, cb_data);
+    }
+
+    if (_ogx_efb_content_type == OGX_EFB_STENCIL) {
+        u16 width = GX_GetTexObjWidth(&s_stencil_texture);
+        u16 height = GX_GetTexObjHeight(&s_stencil_texture);
+        GX_DrawDone();
+        check_bounding_box();
+        debug(OGX_LOG_STENCIL, "Saving EFB to stencil buffer, restoring color");
+        _ogx_efb_save_to_buffer(s_stencil_format, width, height,
+                                s_stencil_buffer, OGX_EFB_COLOR);
+        _ogx_efb_restore(OGX_EFB_COLOR);
+        _ogx_efb_content_type = OGX_EFB_SCENE;
+    }
+
+    glparamstate.dirty.bits.dirty_texture_gen = 1;
+}
+
+void _ogx_stencil_enabled()
+{
+    glparamstate.stencil.enabled = 1;
+    glparamstate.dirty.bits.dirty_stencil = 1;
+}
+
+void _ogx_stencil_disabled()
+{
+    glparamstate.stencil.enabled = 0;
+    glparamstate.dirty.bits.dirty_stencil = 1;
+}
+
+void _ogx_stencil_update()
+{
+    u16 width = glparamstate.viewport[2];
+    u16 height = glparamstate.viewport[3];
+    if (width == 0 || height == 0) return;
+
+    u16 old_width = GX_GetTexObjWidth(&s_stencil_texture);
+    u16 old_height = GX_GetTexObjHeight(&s_stencil_texture);
+    if (width == old_width && height == old_height) return;
+
+    /* This method also gets called when the viewport size changes. Get rid of
+     * any existing stencil buffer. */
+    if (s_stencil_buffer) {
+        free(MEM_PHYSICAL_TO_K0(GX_GetTexObjData(&s_stencil_texture)));
+        free(s_stencil_buffer);
+        s_stencil_buffer = NULL;
+    }
+
+    if (!s_wants_stencil) return;
+
+    u8 format = s_stencil_format;
+    u32 size = GX_GetTexBufferSize(width, height, format, 0, GX_FALSE);
+    s_stencil_buffer = memalign(32, size);
+    memset(s_stencil_buffer, 0, size);
+    DCStoreRangeNoSync(s_stencil_buffer, size);
+    void *stencil_texels = memalign(32, size);
+    memset(stencil_texels, 0, size);
+    DCStoreRange(stencil_texels, size);
+
+    GX_InitTexObj(&s_stencil_texture, stencil_texels, width, height,
+                  format, GX_CLAMP, GX_CLAMP, GX_FALSE);
+    GX_InitTexObjLOD(&s_stencil_texture, GX_NEAR, GX_NEAR,
+                     0.0f, 0.0f, 0.0f, 0, 0, GX_ANISO_1);
+    GX_InvalidateTexAll();
+}
+
+void _ogx_stencil_clear()
+{
+    if (!s_wants_stencil) return;
+
+    u16 width = GX_GetTexObjWidth(&s_stencil_texture);
+    u16 height = GX_GetTexObjHeight(&s_stencil_texture);
+    u32 size = GX_GetTexBufferSize(width, height, s_stencil_format,
+                                   0, GX_FALSE);
+    int value = glparamstate.stencil.clear;
+    if (!(s_stencil_flags & OGX_STENCIL_8BIT)) {
+        value |= value << 4;
+    }
+    if (s_stencil_buffer) {
+        memset(s_stencil_buffer, value, size);
+        DCStoreRangeNoSync(s_stencil_buffer, size);
+    }
+    uint8_t *texels = GX_GetTexObjData(&s_stencil_texture);
+    if (texels) {
+        texels = MEM_PHYSICAL_TO_K0(texels);
+        /* TODO: do this only for direct comparisons, otherwise set
+         * s_stencil_texture_needs_update to true */
+        memset(texels, value, size);
+        DCStoreRange(texels, size);
+        GX_InvalidateTexAll();
+    }
+
+    s_stencil_texture_needs_update = false;
+}
+
+void ogx_stencil_create(OgxStencilFlags flags)
+{
+    s_wants_stencil = true;
+    s_stencil_flags = flags;
+    if (flags & OGX_STENCIL_8BIT) {
+        s_stencil_format = GX_CTF_R8;
+    } else {
+        /* reduce the masks to 4 bits */
+        glparamstate.stencil.mask &= 0xf;
+        glparamstate.stencil.wmask &= 0xf;
+    }
+    _ogx_stencil_update();
+}
+
+void glStencilFunc(GLenum func, GLint ref, GLuint mask)
+{
+    uint8_t new_func = gx_compare_from_gl(func);
+    /* No sense in storing more than the lower 8 bits */
+    uint8_t new_ref = (uint8_t)ref;
+    uint8_t new_mask = (uint8_t)mask;
+    if (!(s_stencil_flags & OGX_STENCIL_8BIT)) {
+        new_mask &= 0xf;
+        new_ref &= 0xf;
+    }
+    if (new_func != glparamstate.stencil.func) {
+        uint8_t old_masked_ref =
+            glparamstate.stencil.ref & glparamstate.stencil.mask;
+        TevComparisonType old_type =
+            comparison_type(glparamstate.stencil.func, old_masked_ref);
+        TevComparisonType new_type =
+            comparison_type(new_func, new_ref & new_mask);
+
+        glparamstate.stencil.func = new_func;
+        if (tev_stage_needed(new_type) && new_type != old_type)
+            s_stencil_texture_needs_update = true;
+    }
+    if (new_ref != glparamstate.stencil.ref) {
+        glparamstate.stencil.ref = new_ref;
+        s_stencil_texture_needs_update = true;
+    }
+    if (new_mask != glparamstate.stencil.mask) {
+        glparamstate.stencil.mask = new_mask;
+        s_stencil_texture_needs_update = true;
+    }
+}
+
+void glStencilMask(GLuint mask)
+{
+    glparamstate.stencil.wmask = (uint8_t)mask;
+    if (!(s_stencil_flags & OGX_STENCIL_8BIT)) {
+        glparamstate.stencil.wmask &= 0xf;
+    }
+}
+
+void glStencilOp(GLenum fail, GLenum zfail, GLenum zpass)
+{
+    glparamstate.stencil.op_fail = fail;
+    glparamstate.stencil.op_zfail = zfail;
+    glparamstate.stencil.op_zpass = zpass;
+}
+
+void glClearStencil(GLint s)
+{
+    glparamstate.stencil.clear = (uint8_t)s;
+}

--- a/src/stencil.h
+++ b/src/stencil.h
@@ -1,5 +1,6 @@
 /*****************************************************************************
 Copyright (c) 2011  David Guillen Fandos (david@davidgf.net)
+Copyright (c) 2024  Alberto Mardegan (mardy@users.sourceforge.net)
 All rights reserved.
 
 Attention! Contains pieces of code from others such as Mesa and GRRLib
@@ -29,34 +30,23 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#ifndef OGX_DEBUG_H
-#define OGX_DEBUG_H
+#ifndef OPENGX_STENCIL_H
+#define OPENGX_STENCIL_H
 
-#include <ogc/system.h>
-#include <errno.h>
-#include <stdio.h>
+#include <GL/gl.h>
+#include <malloc.h>
+#include <stdbool.h>
 
-typedef enum {
-    OGX_LOG_WARNING = 1 << 0,
-    OGX_LOG_CALL_LISTS = 1 << 1,
-    OGX_LOG_LIGHTING = 1 << 2,
-    OGX_LOG_TEXTURE = 1 << 3,
-    OGX_LOG_STENCIL = 1 << 4,
-} OgxLogMask;
+void _ogx_stencil_enabled(void);
+void _ogx_stencil_disabled(void);
+void _ogx_stencil_update(void);
+void _ogx_stencil_clear(void);
 
-extern OgxLogMask _ogx_log_mask;
+bool _ogx_stencil_setup_tev(int *stages, int *tex_coords, int tex_map);
 
-/* Warning are always emitted unless the mask is 0 */
-#define warning(format, ...) \
-    if (_ogx_log_mask) { \
-        SYS_Report(format "\n", ##__VA_ARGS__); \
-    }
+/* This callback should draw the current primitive with no color, lighting or
+ * textures */
+typedef void (*OgxStencilDrawCallback)(void *data);
+void _ogx_stencil_draw(OgxStencilDrawCallback callback, void *cb_data);
 
-#define debug(mask, format, ...) \
-    if (_ogx_log_mask & mask) { \
-        SYS_Report(format "\n", ##__VA_ARGS__); \
-    }
-
-void _ogx_log_init();
-
-#endif /* OGX_DEBUG_H */
+#endif /* OPENGX_STENCIL_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -259,4 +259,9 @@ static inline uint8_t gx_compare_from_gl(GLenum func)
 /* Set up the matrices for 2D pixel-perfect drawing */
 void _ogx_setup_2D_projection(void);
 
+/* Set the OpenGL 3D modelview and projection matrices */
+void _ogx_setup_3D_projection(void);
+
+bool _ogx_setup_render_stages(void);
+
 #endif /* OGX_UTILS_H */


### PR DESCRIPTION
Finally it's here :-)

This is a big changeset all in one commit, but that's because I didn't find it worthwhile splitting it into smaller chunks (if you disagree, please let me know, I can try to come up with some splits).

The code has some inline comments, but for an overview one should read the "Stencil Test" section in the [OpenGL 1.5 specification](https://registry.khronos.org/OpenGL/specs/gl/glspec15.pdf) first, then the documentation changes from the second commit of this PR.

This has been tested with the tutorial №27 from swiftless.com and with the [dinoshade.c](https://github.com/markkilgard/glut/blob/master/progs/examples/dinoshade.c) program that can be found online in the examples of the GLU library.