### PR TITLE
Support clients defining weak symbols of opengx functions

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -38,6 +38,8 @@ typedef struct {
     void *address;
 } ProcMap;
 
+int _ogx_functions_c = 0; /* referenced by gc_gl.c, see the comment in there */
+
 #define PROC(name) { #name, name }
 static const ProcMap s_proc_map[] = {
     //PROC(glAccum),

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -79,6 +79,13 @@ typedef struct
 char _ogx_log_level = 0;
 static GXTexObj s_zbuffer_texture;
 static uint8_t s_zbuffer_texels[2 * 32] ATTRIBUTE_ALIGN(32);
+/* Force the inclusion of functions.c's TU in the build when GL functions are
+ * used. In this way, if a client library (such as SDL) defines weak symbols
+ * for the opengx functions it uses, a client application which actually uses
+ * opengx will link and use its real implementation; at the same time, a client
+ * which does not use OpenGL is not forced to link with opengx. */
+extern int _ogx_functions_c;
+void *_ogx_force_proctable = &_ogx_functions_c;
 
 static void draw_arrays_general(DrawMode gxmode, int first, int count, int ne,
                                 int color_provide, int texen);


### PR DESCRIPTION
With this change, the translation unit (TU) of functions.c gets brought
into the list of units used in the linking when a gc_gl.c's TU is used,
as confirmed by nm:

    functions.o:
    ...
    00000000 B _ogx_functions_c
    00000000 T ogx_get_proc_address
    ...

    gc_gl.o:
    ...
    00000000 D _ogx_force_proctable
             U _ogx_functions_c
    00000000 T ogx_initialize
    ...

As the comment in the code explains it, this allows us to support the
scenario where we use opengx in a client library (such as SDL) without
forcing a dependency on it in the client application. More precisely,
this change is made to support the case where an application *does use*
opengx via libSDL, to make so that the weak symbol for
ogx_get_proc_address() defined in libSDL gets overridden by the real one
(since the application is unlikely to use this function directly, but
it's indirectly used when SDL_GL_GetProcAddress() is called).
