### PR TITLE
Refactor EFB switching

### DIFF
--- a/src/efb.h
+++ b/src/efb.h
@@ -51,11 +51,31 @@ typedef enum {
 
 extern OgxEfbContentType _ogx_efb_content_type;
 
-void _ogx_efb_save(OgxEfbFlags flags);
-void _ogx_efb_restore(OgxEfbFlags flags);
-
 void _ogx_efb_save_to_buffer(uint8_t format, uint16_t width, uint16_t height,
                              void *texels, OgxEfbFlags flags);
 void _ogx_efb_restore_texobj(GXTexObj *texobj);
+
+typedef struct {
+    GXTexObj texobj;
+    /* buffer-specific counter indicating what was the last draw operation
+     * saved into this buffer */
+    int draw_count;
+    /* The texel data are stored in the same memory block at the end of this
+     * struct */
+    _Alignas(32) uint8_t texels[0];
+} OgxEfbBuffer;
+
+void _ogx_efb_buffer_prepare(OgxEfbBuffer **buffer, uint8_t format);
+void _ogx_efb_buffer_handle_resize(OgxEfbBuffer **buffer);
+void _ogx_efb_buffer_save(OgxEfbBuffer *buffer, OgxEfbFlags flags);
+
+void _ogx_efb_set_content_type_real(OgxEfbContentType content_type);
+
+/* We inline this part since most of the times the desired content type will be
+ * the one already active */
+static inline void _ogx_efb_set_content_type(OgxEfbContentType content_type) {
+    if (content_type == _ogx_efb_content_type) return;
+    _ogx_efb_set_content_type_real(content_type);
+}
 
 #endif /* OPENGX_EFB_H */

--- a/src/efb.h
+++ b/src/efb.h
@@ -36,6 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <GL/gl.h>
 #include <malloc.h>
 #include <ogc/gx.h>
+#include <ogc/system.h>
 
 typedef enum {
     OGX_EFB_NONE = 0,
@@ -68,6 +69,10 @@ typedef struct {
 void _ogx_efb_buffer_prepare(OgxEfbBuffer **buffer, uint8_t format);
 void _ogx_efb_buffer_handle_resize(OgxEfbBuffer **buffer);
 void _ogx_efb_buffer_save(OgxEfbBuffer *buffer, OgxEfbFlags flags);
+static inline void *_ogx_efb_buffer_get_texels(OgxEfbBuffer *buffer) {
+    void *texels = GX_GetTexObjData(&buffer->texobj);
+    return texels ? MEM_PHYSICAL_TO_K0(texels) : NULL;
+}
 
 void _ogx_efb_set_content_type_real(OgxEfbContentType content_type);
 

--- a/src/stencil.c
+++ b/src/stencil.c
@@ -447,8 +447,6 @@ static bool draw_op(uint16_t op,
     if (_ogx_efb_content_type == OGX_EFB_SCENE) {
         debug(OGX_LOG_STENCIL, "Saving scene EFB, clearing, loading stencil");
 
-        GXColor black = { 0, 0, 0, 255 };
-        GX_SetCopyClear(black, GX_MAX_Z24);
         GX_DrawDone();
         _ogx_efb_save(OGX_EFB_COLOR);
 

--- a/src/stencil.h
+++ b/src/stencil.h
@@ -53,4 +53,7 @@ bool _ogx_stencil_setup_tev(int *stages, int *tex_coords,
 typedef void (*OgxStencilDrawCallback)(void *data);
 void _ogx_stencil_draw(OgxStencilDrawCallback callback, void *cb_data);
 
+void _ogx_stencil_load_into_efb();
+void _ogx_stencil_save_to_efb();
+
 #endif /* OPENGX_STENCIL_H */


### PR DESCRIPTION
Refactor the existing code in stencil.c, where the EFB was saved and later restored when switching between the stencil and scene drawing targets, to make it more generic and able to support more    drawing targets. Now there is a centralized function,    _ogx_efb_set_content_type(), which will take care of invoking the right    functions to save the current EFB contents to the appropriate buffer, as    well as to load the target buffer (and set it up, if it had not been    used before).
    
This will allow us to more easily support the accumulation buffer (see the glAccum function).
