### PR TITLE
call-lists: correctly handle glColor() commands

### DIFF
--- a/src/call_lists.c
+++ b/src/call_lists.c
@@ -104,6 +104,8 @@ typedef struct
             GLfloat z;
         } rotate;
 
+        float color[4];
+
         float matrix[16];
     } c;
 } Command;
@@ -264,6 +266,9 @@ static void run_command(Command *cmd)
         break;
     case COMMAND_FRONT_FACE:
         glFrontFace(cmd->c.mode);
+        break;
+    case COMMAND_COLOR:
+        glColor4fv(cmd->c.color);
         break;
     }
 
@@ -457,6 +462,9 @@ bool _ogx_call_list_append(CommandType op, ...)
         break;
     case COMMAND_FRONT_FACE:
         command->c.mode = va_arg(ap, GLenum);
+        break;
+    case COMMAND_COLOR:
+        floatcpy(command->c.color, va_arg(ap, GLfloat *), 4);
         break;
     }
     va_end(ap);

--- a/src/call_lists.h
+++ b/src/call_lists.h
@@ -35,6 +35,10 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "state.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Except when specified otherwise, the enum name matches the GL function
  * (e.g., COMMAND_ENABLE == glEnable)
  */
@@ -59,6 +63,7 @@ typedef enum {
     COMMAND_ROTATE,
     COMMAND_SCALE,
     COMMAND_FRONT_FACE,
+    COMMAND_COLOR,
 } CommandType;
 
 #define HANDLE_CALL_LIST(operation, ...) \
@@ -69,5 +74,9 @@ typedef enum {
     }
 
 bool _ogx_call_list_append(CommandType op, ...);
+
+#ifdef __cplusplus
+} // extern C
+#endif
 
 #endif /* OPENGX_CALL_LISTS_H */

--- a/src/vertex.cpp
+++ b/src/vertex.cpp
@@ -30,6 +30,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
+#include "call_lists.h"
 #include "debug.h"
 #include "state.h"
 #include "utils.h"
@@ -51,10 +52,7 @@ T full_color()
 template <typename T>
 void set_current_color(T red, T green, T blue, T alpha = full_color<T>())
 {
-    if (glparamstate.imm_mode.in_gl_begin)
-        glparamstate.imm_mode.has_color = 1;
-
-    auto &c = glparamstate.imm_mode.current_color;
+    float c[4];
     if constexpr (std::is_floating_point<T>::value) {
         c[0] = red;
         c[1] = green;
@@ -71,6 +69,14 @@ void set_current_color(T red, T green, T blue, T alpha = full_color<T>())
         c[2] = blue / max;
         c[3] = alpha / max;
     }
+
+    if (glparamstate.imm_mode.in_gl_begin) {
+        glparamstate.imm_mode.has_color = 1;
+    } else {
+        HANDLE_CALL_LIST(COLOR, c);
+    }
+
+    floatcpy(glparamstate.imm_mode.current_color, c, 4);
 }
 
 static inline void set_current_tex_coords(float s, float t = 0)


### PR DESCRIPTION
In call lists we were properly handling glColor() calls if they appeared within glBegin()/glEnd(), otherwise they were ignored.

Fix this by storing these commands too in the call lists.