### PR TITLE
Misc fixes: lists, stencil, EFB issues

### DIFF
--- a/src/call_lists.c
+++ b/src/call_lists.c
@@ -107,6 +107,8 @@ typedef struct
 
         float color[4];
 
+        float normal[3];
+
         float matrix[16];
     } c;
 } Command;
@@ -273,8 +275,10 @@ static void run_command(Command *cmd)
     case COMMAND_COLOR:
         glColor4fv(cmd->c.color);
         break;
+    case COMMAND_NORMAL:
+        glNormal3fv(cmd->c.normal);
+        break;
     }
-
 }
 
 static void open_gxlist(Command *command)
@@ -468,6 +472,9 @@ bool _ogx_call_list_append(CommandType op, ...)
         break;
     case COMMAND_COLOR:
         floatcpy(command->c.color, va_arg(ap, GLfloat *), 4);
+        break;
+    case COMMAND_NORMAL:
+        floatcpy(command->c.normal, va_arg(ap, GLfloat *), 3);
         break;
     }
     va_end(ap);

--- a/src/call_lists.h
+++ b/src/call_lists.h
@@ -45,7 +45,6 @@ extern "C" {
 typedef enum {
     COMMAND_NONE, /* The command entry is unused, it means we reached the end
                      of the call list */
-    COMMAND_GXLIST, /* Execute a GX call list */
     COMMAND_DRAW_ARRAYS,
     COMMAND_DRAW_ELEMENTS,
     COMMAND_CALL_LIST,

--- a/src/call_lists.h
+++ b/src/call_lists.h
@@ -47,6 +47,7 @@ typedef enum {
                      of the call list */
     COMMAND_GXLIST, /* Execute a GX call list */
     COMMAND_DRAW_ARRAYS,
+    COMMAND_DRAW_ELEMENTS,
     COMMAND_CALL_LIST,
     COMMAND_ENABLE,
     COMMAND_DISABLE,

--- a/src/call_lists.h
+++ b/src/call_lists.h
@@ -64,6 +64,7 @@ typedef enum {
     COMMAND_SCALE,
     COMMAND_FRONT_FACE,
     COMMAND_COLOR,
+    COMMAND_NORMAL,
 } CommandType;
 
 #define HANDLE_CALL_LIST(operation, ...) \

--- a/src/efb.c
+++ b/src/efb.c
@@ -111,7 +111,7 @@ void _ogx_efb_buffer_prepare(OgxEfbBuffer **buffer, uint8_t format)
 
     u16 width = glparamstate.viewport[2];
     u16 height = glparamstate.viewport[3];
-    u32 size = GX_GetTexBufferSize(width, height, GX_TF_RGBA8, 0, GX_FALSE);
+    u32 size = GX_GetTexBufferSize(width, height, format, 0, GX_FALSE);
     OgxEfbBuffer *b = memalign(32, size + sizeof(OgxEfbBuffer));
     void *texels = &(b->texels[0]);
     DCInvalidateRange(texels, size);

--- a/src/efb.c
+++ b/src/efb.c
@@ -151,5 +151,6 @@ void _ogx_efb_buffer_save(OgxEfbBuffer *buffer, OgxEfbFlags flags)
     u16 width, height;
     GX_GetTexObjAll(&buffer->texobj, &texels, &width, &height, &format,
                     &unused, &unused, &unused);
+    texels = MEM_PHYSICAL_TO_K0(texels);
     _ogx_efb_save_to_buffer(format, width, height, texels, flags);
 }

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -908,6 +908,7 @@ void glBegin(GLenum mode)
     glparamstate.imm_mode.prim_type = mode;
     glparamstate.imm_mode.in_gl_begin = 1;
     glparamstate.imm_mode.has_color = 0;
+    glparamstate.imm_mode.has_normal = 0;
     if (!glparamstate.imm_mode.current_vertices) {
         int count = 64;
         warning("First malloc %d", errno);
@@ -944,7 +945,7 @@ void glEnd()
     _ogx_array_reader_set_num_elements(&glparamstate.vertex_array, 3);
     glparamstate.cs.texcoord_enabled = 1;
     glparamstate.cs.color_enabled = glparamstate.imm_mode.has_color;
-    glparamstate.cs.normal_enabled = 1;
+    glparamstate.cs.normal_enabled = glparamstate.imm_mode.has_normal;
     glparamstate.cs.vertex_enabled = 1;
     glDrawArrays(glparamstate.imm_mode.prim_type, 0, glparamstate.imm_mode.current_numverts);
     glparamstate.cs = cs_backup;

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -225,6 +225,7 @@ void ogx_initialize()
     glparamstate.glcullmode = GL_BACK;
     glparamstate.render_mode = GL_RENDER;
     glparamstate.cullenabled = 0;
+    glparamstate.polygon_mode = GL_FILL;
     glparamstate.color_update = true;
     glparamstate.alpha_func = GX_ALWAYS;
     glparamstate.alpha_ref = 0;
@@ -1435,6 +1436,16 @@ void glLineWidth(GLfloat width)
     GX_SetLineWidth((unsigned int)(width * 16), GX_TO_ZERO);
 }
 
+void glPolygonMode(GLenum face, GLenum mode)
+{
+    if (face != GL_FRONT_AND_BACK) {
+        warning("glPolygonMode: face selection is unsupported");
+        return;
+    }
+
+    glparamstate.polygon_mode = mode;
+}
+
 void glPolygonOffset(GLfloat factor, GLfloat units)
 {
     glparamstate.polygon_offset_factor = factor;
@@ -1854,6 +1865,17 @@ static LightMasks prepare_lighting()
 DrawMode _ogx_draw_mode(GLenum mode)
 {
     DrawMode dm = { 0xff, false };
+
+    if (glparamstate.polygon_mode != GL_FILL) {
+        if (glparamstate.polygon_mode == GL_POINT) {
+            dm.mode = GX_POINTS;
+        } else { // GL LINE
+            dm.mode = GX_LINESTRIP;
+            dm.loop = true;
+        }
+        return dm;
+    }
+
     switch (mode) {
     case GL_POINTS:
         dm.mode = GX_POINTS;
@@ -2589,7 +2611,6 @@ void glPushAttrib(GLbitfield mask) {}
 void glPopAttrib(void) {}
 void glPushClientAttrib(GLbitfield mask) {}
 void glPopClientAttrib(void) {}
-void glPolygonMode(GLenum face, GLenum mode) {}
 void glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid *data) {}
 
 /*

--- a/src/state.h
+++ b/src/state.h
@@ -182,6 +182,7 @@ typedef struct glparams_
         GLenum prim_type;
         unsigned in_gl_begin : 1;
         unsigned has_color : 1;
+        unsigned has_normal : 1;
     } imm_mode;
 
     union dirty_union

--- a/src/state.h
+++ b/src/state.h
@@ -125,6 +125,7 @@ typedef struct glparams_
     GLenum glcullmode;
     GLenum render_mode;
     GLenum active_buffer; /* no separate buffers for reading and writing */
+    GLenum polygon_mode;
     int glcurtex;
     int draw_count;
     GXColor clear_color;

--- a/src/stencil.c
+++ b/src/stencil.c
@@ -470,8 +470,9 @@ static bool draw_op(uint16_t op,
     GX_SetTevAlphaOp(stage, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1,
                      GX_TRUE, GX_TEVPREV);
     GX_SetNumChans(1);
+    GX_SetChanCtrl(GX_COLOR0A0, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, 0, GX_DF_NONE, GX_AF_NONE);
 
-    GX_SetChanCtrl(GX_COLOR0A0, GX_DISABLE, GX_SRC_VTX, GX_SRC_VTX, 0, GX_DF_NONE, GX_AF_NONE);
+
     if (check_stencil) {
         bool must_draw =
             setup_tev_full(&num_stages, &num_tex_coords,

--- a/src/stencil.c
+++ b/src/stencil.c
@@ -292,7 +292,7 @@ static bool setup_tev_full(int *stages, int *tex_coords,
     }
 
     debug(OGX_LOG_STENCIL, "%d TEV stages, %d tex_coords, %d tex_maps",
-          *stages, *tex_coords, tex_maps);
+          *stages, *tex_coords, *tex_maps);
     u8 logical_op;
     u8 ref_value = GX_CA_KONST;
     bool invert_operands = false;

--- a/src/utils.h
+++ b/src/utils.h
@@ -125,6 +125,11 @@ static inline void mtx44project(const Mtx44 p, const guVector *v,
     }
 }
 
+static inline bool gxcol_equal(GXColor a, GXColor b)
+{
+    return *(int32_t*)&a == *(int32_t*)&b;
+}
+
 static inline GXColor gxcol_new_fv(float *components)
 {
     GXColor c = {
@@ -159,6 +164,14 @@ static inline void set_error(GLenum code)
     if (!glparamstate.error) {
         glparamstate.error = code;
     }
+}
+
+extern uint16_t _ogx_draw_sync_token;
+static inline uint16_t send_draw_sync_token()
+{
+    uint16_t token = ++_ogx_draw_sync_token;
+    GX_SetDrawSync(token);
+    return token;
 }
 
 typedef void (*ForeachCb)(GLuint value);
@@ -289,6 +302,14 @@ static inline GLenum gl_compare_from_gx(uint8_t func)
     default: return GL_NEVER;
     }
 }
+
+typedef struct
+{
+    uint8_t mode;
+    bool loop;
+} DrawMode;
+
+DrawMode _ogx_draw_mode(GLenum mode);
 
 /* Set up the matrices for 2D pixel-perfect drawing */
 void _ogx_setup_2D_projection(void);

--- a/src/vertex.cpp
+++ b/src/vertex.cpp
@@ -251,9 +251,8 @@ void glNormal3d(GLdouble nx, GLdouble ny, GLdouble nz)
 
 void glNormal3f(GLfloat nx, GLfloat ny, GLfloat nz)
 {
-    glparamstate.imm_mode.current_normal[0] = nx;
-    glparamstate.imm_mode.current_normal[1] = ny;
-    glparamstate.imm_mode.current_normal[2] = nz;
+    float v[3] = { nx, ny, nz };
+    glNormal3fv(v);
 }
 
 void glNormal3i(GLint nx, GLint ny, GLint nz)
@@ -278,7 +277,12 @@ void glNormal3dv(const GLdouble *v)
 
 void glNormal3fv(const GLfloat *v)
 {
-    glNormal3f(v[0], v[1], v[2]);
+    if (glparamstate.imm_mode.in_gl_begin) {
+        glparamstate.imm_mode.has_normal = 1;
+    } else {
+        HANDLE_CALL_LIST(NORMAL, v);
+    }
+    floatcpy(glparamstate.imm_mode.current_normal, v, 3);
 }
 
 void glNormal3iv(const GLint *v)


### PR DESCRIPTION
The biggest commits are about changing the handling of glDrawElements() and glDrawArrays() inside glCallList(): instead of merging different lists together, now each command is played back individually (allowing the stencil buffer to update in between). Also, fix the handling of vertex normals when they were not specified at list creation time (we must use the current normal vector in that case).

A couple of commits are about implementing glPolygonMode() (which would have been impossible to implement in call lists if we hadn't changed the list implementation).

Other commits are smallers and don't need additional explanation beside what is in their commit message.