### PR TITLE
Implement VBOs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,9 @@ add_library(${TARGET} STATIC
     src/stencil.h
     src/texel.h
     src/texture.c
+    src/types.h
     src/utils.h
+    src/vbo.c
     src/vertex.cpp
 )
 set_target_properties(${TARGET} PROPERTIES

--- a/include/GL/glext.h
+++ b/include/GL/glext.h
@@ -3736,7 +3736,6 @@ typedef void (APIENTRYP PFNGLWINDOWPOS3SPROC) (GLshort x, GLshort y, GLshort z);
 typedef void (APIENTRYP PFNGLWINDOWPOS3SVPROC) (const GLshort *v);
 #endif
 
-#if 0 /* Until we don't really support it, disable alll GL > 1.4 */
 #ifndef GL_VERSION_1_5
 #define GL_VERSION_1_5 1
 #ifdef GL_GLEXT_PROTOTYPES
@@ -3989,7 +3988,6 @@ typedef void (APIENTRYP PFNGLUNIFORMMATRIX2X4FVPROC) (GLint location, GLsizei co
 typedef void (APIENTRYP PFNGLUNIFORMMATRIX4X2FVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
 typedef void (APIENTRYP PFNGLUNIFORMMATRIX3X4FVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
 typedef void (APIENTRYP PFNGLUNIFORMMATRIX4X3FVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-#endif
 #endif
 
 #ifndef GL_ARB_multitexture

--- a/src/arrays.h
+++ b/src/arrays.h
@@ -45,11 +45,16 @@ typedef struct {
 } OgxArrayReader;
 
 void _ogx_array_reader_init(OgxArrayReader *reader,
+                            uint8_t vertex_attribute,
                             const void *data,
-                            GLenum type, int stride);
-void _ogx_array_reader_set_num_elements(OgxArrayReader *reader, int n);
-void _ogx_array_reader_read_float(OgxArrayReader *reader,
-                                  int index, float *elements);
+                            int num_components, GLenum type, int stride);
+void _ogx_array_reader_setup_draw(OgxArrayReader *reader);
+void _ogx_array_reader_setup_draw_color(OgxArrayReader *reader,
+                                        bool dup_color);
+void _ogx_array_reader_enable_dup_color(OgxArrayReader *reader,
+                                        bool dup_color);
+void _ogx_array_reader_process_element(OgxArrayReader *reader, int index);
+
 void _ogx_array_reader_read_pos3f(OgxArrayReader *reader,
                                   int index, float *pos);
 void _ogx_array_reader_read_norm3f(OgxArrayReader *reader,

--- a/src/functions.c
+++ b/src/functions.c
@@ -411,6 +411,17 @@ static int compare_proc(const void *a_ptr, const void *b_ptr)
 
 void *ogx_get_proc_address(const char *proc)
 {
+    char buffer[64];
+    size_t len;
+
+    /* If the string ends with the "ARB" suffix, remove it */
+    len = strlen(proc);
+    if (len > 3 && strcmp(proc + len - 3, "ARB") == 0) {
+        strncpy(buffer, proc, len - 3);
+        buffer[len - 3] = '\0';
+        proc = buffer;
+    }
+
     ProcMap search = { proc, NULL };
     ProcMap *elem = bsearch(&search, s_proc_map, NUM_PROCS, sizeof(ProcMap),
                             compare_proc);

--- a/src/functions.c
+++ b/src/functions.c
@@ -28,6 +28,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
+#define GL_GLEXT_PROTOTYPES 1
 #include "opengx.h"
 
 #include <stdlib.h>
@@ -48,9 +49,13 @@ static const ProcMap s_proc_map[] = {
     PROC(glArrayElement),
     PROC(glBegin),
     PROC(glBegin),
+    //PROC(glBeginQuery), /* OpenGL 1.5 */
+    PROC(glBindBuffer), /* OpenGL 1.5 */
     PROC(glBindTexture),
     PROC(glBitmap),
     PROC(glBlendFunc),
+    PROC(glBufferData), /* OpenGL 1.5 */
+    PROC(glBufferSubData), /* OpenGL 1.5 */
     PROC(glCallList),
     PROC(glCallLists),
     PROC(glClear),
@@ -101,7 +106,9 @@ static const ProcMap s_proc_map[] = {
     //PROC(glCopyTexSubImage1D),
     //PROC(glCopyTexSubImage2D),
     PROC(glCullFace),
+    PROC(glDeleteBuffers), /* OpenGL 1.5 */
     PROC(glDeleteLists),
+    //PROC(glDeleteQueries), /* OpenGL 1.5 */
     PROC(glDeleteTextures),
     PROC(glDepthFunc),
     PROC(glDepthMask),
@@ -119,6 +126,7 @@ static const ProcMap s_proc_map[] = {
     PROC(glEnableClientState),
     PROC(glEnd),
     PROC(glEndList),
+    //PROC(glEndQuery), /* OpenGL 1.5 */
     //PROC(glEvalCoord1d),
     //PROC(glEvalCoord1dv),
     //PROC(glEvalCoord1f),
@@ -140,9 +148,14 @@ static const ProcMap s_proc_map[] = {
     //PROC(glFogiv),
     PROC(glFrontFace),
     PROC(glFrustum),
+    PROC(glGenBuffers), /* OpenGL 1.5 */
     PROC(glGenLists),
+    //PROC(glGenQueries), /* OpenGL 1.5 */
     PROC(glGenTextures),
     //PROC(glGetBooleanv),
+    PROC(glGetBufferParameteriv), /* OpenGL 1.5 */
+    PROC(glGetBufferPointerv), /* OpenGL 1.5 */
+    PROC(glGetBufferSubData), /* OpenGL 1.5 */
     //PROC(glGetClipPlane),
     PROC(glGetDoublev),
     PROC(glGetError),
@@ -160,6 +173,9 @@ static const ProcMap s_proc_map[] = {
     PROC(glGetPixelMapusv),
     //PROC(glGetPointerv),
     //PROC(glGetPolygonStipple),
+    //PROC(glGetQueryObjectiv), /* OpenGL 1.5 */
+    //PROC(glGetQueryObjectuiv), /* OpenGL 1.5 */
+    //PROC(glGetQueryiv), /* OpenGL 1.5 */
     PROC(glGetString),
     //PROC(glGetTexEnvfv),
     //PROC(glGetTexEnviv),
@@ -186,8 +202,10 @@ static const ProcMap s_proc_map[] = {
     //PROC(glIndexubv),
     PROC(glInitNames),
     PROC(glInterleavedArrays),
+    PROC(glIsBuffer), /* OpenGL 1.5 */
     PROC(glIsEnabled),
     PROC(glIsList),
+    //PROC(glIsQuery), /* OpenGL 1.5 */
     //PROC(glIsTexture),
     PROC(glLightModelf),
     PROC(glLightModelfv),
@@ -209,6 +227,7 @@ static const ProcMap s_proc_map[] = {
     //PROC(glMap1f),
     //PROC(glMap2d),
     //PROC(glMap2f),
+    PROC(glMapBuffer), /* OpenGL 1.5 */
     //PROC(glMapGrid1d),
     //PROC(glMapGrid1f),
     //PROC(glMapGrid2d),
@@ -353,6 +372,7 @@ static const ProcMap s_proc_map[] = {
     PROC(glTexSubImage2D),
     PROC(glTranslated),
     PROC(glTranslatef),
+    PROC(glUnmapBuffer), /* OpenGL 1.5 */
     PROC(glVertex2d),
     PROC(glVertex2dv),
     PROC(glVertex2f),

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -55,6 +55,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "state.h"
 #include "stencil.h"
 #include "utils.h"
+#include "vbo.h"
 
 #include <GL/gl.h>
 #include <gctypes.h>
@@ -2308,6 +2309,11 @@ static void draw_elements_general(DrawMode gxmode, int count, GLenum type,
 
     // Invalidate vertex data as may have been modified by the user
     GX_InvVtxCache();
+
+    if (glparamstate.bound_vbo_element_array) {
+        indices = _ogx_vbo_get_data(glparamstate.bound_vbo_element_array,
+                                    indices);
+    }
 
     bool loop = gxmode.loop;
     GX_Begin(gxmode.mode, GX_VTXFMT0, count + loop);

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -61,6 +61,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <gctypes.h>
 #include <malloc.h>
 #include <math.h>
+#include <ogc/machine/processor.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -2389,6 +2390,9 @@ void glDrawArrays(GLenum mode, GLint first, GLsizei count)
 
     HANDLE_CALL_LIST(DRAW_ARRAYS, mode, first, count);
 
+    /* If VBOs are in use, make sure their data has been updated */
+    ppcsync();
+
     bool should_draw = true;
     int texen = glparamstate.cs.texcoord_enabled;
     if (glparamstate.stencil.enabled) {
@@ -2428,6 +2432,9 @@ void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indic
         return;
 
     HANDLE_CALL_LIST(DRAW_ELEMENTS, mode, count, type, indices);
+
+    /* If VBOs are in use, make sure their data has been updated */
+    ppcsync();
 
     bool should_draw = true;
     int texen = glparamstate.cs.texcoord_enabled;

--- a/src/getters.c
+++ b/src/getters.c
@@ -160,6 +160,12 @@ void glGetFloatv(GLenum pname, GLfloat *params)
 void glGetIntegerv(GLenum pname, GLint *params)
 {
     switch (pname) {
+    case GL_ARRAY_BUFFER_BINDING:
+        *params = glparamstate.bound_vbo_array;
+        break;
+    case GL_ELEMENT_ARRAY_BUFFER_BINDING:
+        *params = glparamstate.bound_vbo_element_array;
+        break;
     case GL_AUX_BUFFERS:
         *params = 0;
         break;

--- a/src/getters.c
+++ b/src/getters.c
@@ -57,7 +57,7 @@ const GLubyte *glGetString(GLenum name)
     case GL_VERSION:
         return "1.1";
     case GL_EXTENSIONS:
-        return gl_null_string;
+        return "GL_ARB_vertex_buffer_object ";
     default:
         set_error(GL_INVALID_ENUM);
         return gl_null_string;

--- a/src/state.h
+++ b/src/state.h
@@ -33,6 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define OGX_STATE_H
 
 #include "arrays.h"
+#include "types.h"
 
 #include <GL/gl.h>
 #include <gccore.h>
@@ -175,6 +176,9 @@ typedef struct glparams_
     uint16_t pack_image_height;
     uint16_t unpack_row_length;
     uint16_t unpack_image_height;
+
+    VboType bound_vbo_array;
+    VboType bound_vbo_element_array;
 
     struct imm_mode
     {

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,51 @@
+/*****************************************************************************
+Copyright (c) 2011  David Guillen Fandos (david@davidgf.net)
+Copyright (c) 2024  Alberto Mardegan (mardy@users.sourceforge.net)
+All rights reserved.
+
+Attention! Contains pieces of code from others such as Mesa and GRRLib
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL COPYRIGHT HOLDERS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#ifndef OPENGX_TYPES_H
+#define OPENGX_TYPES_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Now we support as much as 255 VBOs, but, should we support more, we'll need
+ * to use a larger type for the index. */
+typedef uint8_t VboType;
+
+#ifdef __cplusplus
+} // extern C
+#endif
+
+#endif /* OPENGX_TYPES_H */

--- a/src/vbo.c
+++ b/src/vbo.c
@@ -1,0 +1,270 @@
+/*****************************************************************************
+Copyright (c) 2024  Alberto Mardegan (mardy@users.sourceforge.net)
+All rights reserved.
+
+Attention! Contains pieces of code from others such as Mesa and GRRLib
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL COPYRIGHT HOLDERS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "debug.h"
+#include "state.h"
+#include "utils.h"
+
+#include <malloc.h>
+
+typedef struct {
+    size_t size;
+    unsigned mapped : 1;
+    /* The buffer data are stored in the same memory block at the end of this
+     * struct */
+    _Alignas(4) uint8_t data[0];
+} VertexBuffer;
+
+#define MAX_VBOS 256 /* Check the size of _ogx_state.bound_vbo_* members if
+                        increasing this! */
+
+static VertexBuffer *s_buffers[MAX_VBOS];
+
+#define RESERVED_PTR ((void*)0x1)
+#define VBO_IS_USED(vbo) \
+    (s_buffers[vbo] != NULL && s_buffers[vbo] != RESERVED_PTR)
+#define VBO_IS_RESERVED(vbo) (s_buffers[vbo] == RESERVED_PTR)
+#define VBO_IS_RESERVED_OR_USED(vbo) (s_buffers[vbo] != NULL)
+#define VBO_RESERVE(vbo) s_buffers[vbo] = RESERVED_PTR;
+
+static VboType *get_buffer_for_target(GLenum target)
+{
+    VboType *buffer = NULL;
+    switch (target) {
+    case GL_ARRAY_BUFFER:
+        buffer = &_ogx_state.bound_vbo_array;
+        break;
+    case GL_ELEMENT_ARRAY_BUFFER:
+        buffer = &_ogx_state.bound_vbo_element_array;
+        break;
+    default:
+        warning("Unsupported target for glBindBuffer: %04x", target);
+        set_error(GL_INVALID_ENUM);
+    }
+    return buffer;
+}
+
+static int get_index_for_target(GLenum target)
+{
+    VboType *target_buffer = get_buffer_for_target(target);
+    if (!target_buffer) return -1;
+
+    VboType active_vbo = *target_buffer;
+    if (active_vbo == 0) {
+        set_error(GL_INVALID_OPERATION);
+    }
+
+    return active_vbo - 1;
+}
+
+void glBindBuffer(GLenum target, GLuint buffer)
+{
+    VboType *target_buffer = get_buffer_for_target(target);
+    if (target_buffer) *target_buffer = buffer;
+}
+
+void glDeleteBuffers(GLsizei n, const GLuint *buffers)
+{
+    const GLuint *vbolist = buffers;
+    GX_DrawDone();
+    while (n-- > 0) {
+        int i = *vbolist++ - 1;
+        if (i >= 0 && i < MAX_VBOS && VBO_IS_USED(i)) {
+            free(s_buffers[i]);
+            s_buffers[i] = NULL;
+        }
+    }
+}
+
+void glGenBuffers(GLsizei n, GLuint *buffers)
+{
+    GLuint *vbolist = buffers;
+    int reserved = 0;
+    for (int i = 0; i < MAX_VBOS && reserved < n; i++) {
+        if (!VBO_IS_RESERVED_OR_USED(i)) {
+            VBO_RESERVE(i);
+            *vbolist++ = i + 1;
+            reserved++;
+        }
+    }
+
+    if (reserved < n) {
+        warning("Could not allocate %d buffers", n);
+        set_error(GL_OUT_OF_MEMORY);
+        /* Unreserve the elements that we reserved just now */
+        for (int i = 0; i < reserved; i++) {
+            s_buffers[buffers[i] - 1] = NULL;
+        }
+    }
+}
+
+GLboolean glIsBuffer(GLuint buffer)
+{
+    if (buffer == 0 || buffer > MAX_VBOS) {
+        return false;
+    }
+
+    int index = buffer - 1;
+    return VBO_IS_RESERVED_OR_USED(index);
+}
+
+static void set_buffer_data(GLenum target, GLintptr offset, GLsizeiptr size,
+                            const void *data, bool must_allocate)
+{
+    int index = get_index_for_target(target);
+    if (index < 0) return;
+
+    if (size <= 0) {
+        if (size < 0) set_error(GL_INVALID_VALUE);
+        return;
+    }
+
+    VertexBuffer *buffer = s_buffers[index];
+    if (must_allocate) {
+        if (buffer && buffer != RESERVED_PTR) free(buffer);
+        buffer = s_buffers[index] = malloc(sizeof(VertexBuffer) + size);
+        if (!buffer) {
+            warning("Out of memory allocating a VBO");
+            set_error(GL_OUT_OF_MEMORY);
+            return;
+        }
+        buffer->size = size;
+        buffer->mapped = false;
+    }
+
+    if (!buffer) {
+        set_error(GL_INVALID_VALUE);
+        return;
+    }
+    if (data) {
+        memcpy(buffer->data + offset, data, size);
+        DCStoreRangeNoSync(buffer->data + offset, size);
+    }
+}
+
+void glBufferData(GLenum target, GLsizeiptr size, const void *data,
+                  GLenum usage)
+{
+    set_buffer_data(target, 0, size, data, true);
+}
+
+void glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size,
+                     const void *data)
+{
+    set_buffer_data(target, offset, size, data, false);
+}
+
+void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, void *data)
+{
+    int index = get_index_for_target(target);
+    if (index < 0) return;
+
+    if (VBO_IS_USED(index)) {
+        memcpy(data, s_buffers[index]->data + offset, size);
+    } else {
+        set_error(GL_INVALID_VALUE);
+    }
+}
+
+void *glMapBuffer(GLenum target, GLenum access)
+{
+    int index = get_index_for_target(target);
+    if (index < 0) return NULL;
+
+    if (!VBO_IS_USED(index)) {
+        set_error(GL_INVALID_VALUE);
+        return NULL;
+    }
+
+    VertexBuffer *buffer = s_buffers[index];
+    buffer->mapped = true;
+    return buffer->data;
+}
+
+GLboolean glUnmapBuffer(GLenum target)
+{
+    int index = get_index_for_target(target);
+    if (index < 0) return GL_FALSE;
+
+    if (!VBO_IS_USED(index)) {
+        set_error(GL_INVALID_VALUE);
+        return GL_FALSE;
+    }
+
+    VertexBuffer *buffer = s_buffers[index];
+    if (!buffer->mapped) {
+        set_error(GL_INVALID_OPERATION);
+        return GL_FALSE;
+    }
+
+    DCStoreRangeNoSync(buffer->data, buffer->size);
+    return GL_TRUE;
+}
+
+void glGetBufferParameteriv(GLenum target, GLenum pname, GLint *params)
+{
+    int index = get_index_for_target(target);
+    if (index < 0) return;
+
+    switch (pname) {
+    case GL_BUFFER_MAPPED:
+        *params = s_buffers[index]->mapped;
+        break;
+    case GL_BUFFER_SIZE:
+        *params = s_buffers[index]->size;
+        break;
+    default:
+        warning("Unhandled buffer parameter %04x", pname);
+    }
+}
+
+void glGetBufferPointerv(GLenum target, GLenum pname, void **params)
+{
+    if (pname != GL_BUFFER_MAP_POINTER) {
+        set_error(GL_INVALID_ENUM);
+        return;
+    }
+
+    int index = get_index_for_target(target);
+    if (index < 0) return;
+
+    if (!VBO_IS_USED(index)) {
+        set_error(GL_INVALID_VALUE);
+        return;
+    }
+    VertexBuffer *buffer = s_buffers[index];
+    *params = buffer->mapped ? buffer->data : NULL;
+}
+
+void *_ogx_vbo_get_data(VboType vbo, const void *offset)
+{
+    return s_buffers[vbo - 1]->data + (int)offset;
+}

--- a/src/vbo.h
+++ b/src/vbo.h
@@ -1,0 +1,49 @@
+/*****************************************************************************
+Copyright (c) 2024  Alberto Mardegan (mardy@users.sourceforge.net)
+All rights reserved.
+
+Attention! Contains pieces of code from others such as Mesa and GRRLib
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL COPYRIGHT HOLDERS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#ifndef OPENGX_VBO_H
+#define OPENGX_VBO_H
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* The offset is a void* because that's how it is specified in most OpenGL APIs
+ * due to compatibility reasons. */
+void *_ogx_vbo_get_data(VboType vbo, const void *offset);
+
+#ifdef __cplusplus
+} // extern C
+#endif
+
+#endif /* OPENGX_VBO_H */


### PR DESCRIPTION
Vertex buffers is a feature from OpenGL 1.5, but also present in older GL versions as an extension.