### PR TITLE
Allow using position and normals as tex coordinates

### DIFF
--- a/src/arrays.cpp
+++ b/src/arrays.cpp
@@ -39,6 +39,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <variant>
 
 static char s_num_tex_arrays = 0;
+static bool s_has_normals = false;
+static uint8_t s_num_colors = 0;
+static uint8_t s_tex_unit_mask = 0;
 
 struct GxVertexFormat {
     uint8_t attribute;
@@ -462,6 +465,32 @@ void _ogx_arrays_setup_draw(bool has_normals, uint8_t num_colors,
         for (int i = 0; i < MAX_TEXTURE_UNITS; i++) {
             if (tex_unit_mask & (1 << i)) {
                 get_reader(&glparamstate.texcoord_array[i])->setup_draw();
+            }
+        }
+    }
+
+    s_has_normals = has_normals;
+    s_num_colors = num_colors;
+    s_tex_unit_mask = tex_unit_mask;
+}
+
+void _ogx_arrays_process_element(int index)
+{
+    get_reader(&glparamstate.vertex_array)->process_element(index);
+
+    if (s_has_normals) {
+        get_reader(&glparamstate.normal_array)->process_element(index);
+    }
+
+    if (s_num_colors) {
+        get_reader(&glparamstate.color_array)->process_element(index);
+    }
+
+    if (s_tex_unit_mask) {
+        for (int i = 0; i < MAX_TEXTURE_UNITS; i++) {
+            if (s_tex_unit_mask & (1 << i)) {
+                get_reader(&glparamstate.texcoord_array[i])->
+                    process_element(index);
             }
         }
     }

--- a/src/arrays.h
+++ b/src/arrays.h
@@ -50,6 +50,7 @@ void _ogx_array_reader_init(OgxArrayReader *reader,
                             int num_components, GLenum type, int stride);
 void _ogx_arrays_setup_draw(bool has_normals, uint8_t num_colors,
                             uint8_t tex_unit_mask);
+void _ogx_arrays_process_element(int index);
 void _ogx_array_reader_enable_dup_color(OgxArrayReader *reader,
                                         bool dup_color);
 void _ogx_array_reader_process_element(OgxArrayReader *reader, int index);

--- a/src/arrays.h
+++ b/src/arrays.h
@@ -54,6 +54,7 @@ void _ogx_arrays_process_element(int index);
 void _ogx_array_reader_enable_dup_color(OgxArrayReader *reader,
                                         bool dup_color);
 void _ogx_array_reader_process_element(OgxArrayReader *reader, int index);
+uint8_t _ogx_array_reader_get_tex_coord_source(OgxArrayReader *reader);
 
 void _ogx_array_reader_read_pos3f(OgxArrayReader *reader,
                                   int index, float *pos);

--- a/src/arrays.h
+++ b/src/arrays.h
@@ -48,10 +48,8 @@ void _ogx_array_reader_init(OgxArrayReader *reader,
                             uint8_t vertex_attribute,
                             const void *data,
                             int num_components, GLenum type, int stride);
-void _ogx_array_reader_setup_draw_start();
-void _ogx_array_reader_setup_draw(OgxArrayReader *reader);
-void _ogx_array_reader_setup_draw_color(OgxArrayReader *reader,
-                                        bool dup_color);
+void _ogx_arrays_setup_draw(bool has_normals, uint8_t num_colors,
+                            uint8_t tex_unit_mask);
 void _ogx_array_reader_enable_dup_color(OgxArrayReader *reader,
                                         bool dup_color);
 void _ogx_array_reader_process_element(OgxArrayReader *reader, int index);

--- a/src/call_lists.c
+++ b/src/call_lists.c
@@ -229,20 +229,17 @@ static void execute_draw_geometry_list(struct DrawGeometry *dg)
         }
     }
 
-    _ogx_array_reader_setup_draw_start();
-    _ogx_array_reader_setup_draw(&glparamstate.vertex_array);
-    if (dg->cs.normal_enabled) {
-        _ogx_array_reader_setup_draw(&glparamstate.normal_array);
-    } else {
+    _ogx_arrays_setup_draw(dg->cs.normal_enabled,
+                           dg->cs.color_enabled ? 2 : 0,
+                           dg->cs.texcoord_enabled);
+    if (!dg->cs.normal_enabled) {
         GX_SetVtxDesc(GX_VA_NRM, GX_INDEX8);
         GX_SetArray(GX_VA_NRM, s_current_normal, 12);
         floatcpy(s_current_normal, glparamstate.imm_mode.current_normal, 3);
         /* Not needed on Dolphin, but it is on a Wii */
         DCStoreRange(s_current_normal, 12);
     }
-    if (dg->cs.color_enabled) {
-        _ogx_array_reader_setup_draw_color(&glparamstate.color_array, true);
-    } else {
+    if (!dg->cs.color_enabled) {
         GX_SetVtxDesc(GX_VA_CLR0, GX_INDEX8);
         GX_SetVtxDesc(GX_VA_CLR1, GX_INDEX8);
         s_current_color = current_color;
@@ -251,13 +248,8 @@ static void execute_draw_geometry_list(struct DrawGeometry *dg)
         DCStoreRange(&s_current_color, 4);
     }
 
-    for (int i = 0; i < MAX_TEXTURE_UNITS; i++) {
-        /* It makes no sense to use a fixed texture coordinates for all vertices,
-         * so we won't add them unless they are enabled. */
-        if (dg->cs.texcoord_enabled & (1 << i)) {
-            _ogx_array_reader_setup_draw(&glparamstate.texcoord_array[i]);
-        }
-    }
+    /* It makes no sense to use a fixed texture coordinates for all vertices,
+     * so we won't add them unless they are enabled. */
 
     GX_InvVtxCache();
 

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -2296,18 +2296,7 @@ static void draw_elements_general(DrawMode gxmode, int count, GLenum type,
                                   const GLvoid *indices,
                                   int ne, int color_provide, int texen)
 {
-    _ogx_array_reader_setup_draw_start();
-    _ogx_array_reader_setup_draw(&glparamstate.vertex_array);
-    if (ne)
-        _ogx_array_reader_setup_draw(&glparamstate.normal_array);
-    if (color_provide)
-        _ogx_array_reader_setup_draw_color(&glparamstate.color_array,
-                                           color_provide == 2);
-    for (int tex = 0; tex < MAX_TEXTURE_UNITS; tex++) {
-        if (texen & (1 << tex)) {
-            _ogx_array_reader_setup_draw(&glparamstate.texcoord_array[tex]);
-        }
-    }
+    _ogx_arrays_setup_draw(ne, color_provide, texen);
 
     // Invalidate vertex data as may have been modified by the user
     GX_InvVtxCache();
@@ -2488,18 +2477,7 @@ void glDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indic
 static void draw_arrays_general(DrawMode gxmode, int first, int count, int ne,
                                 int color_provide, int texen)
 {
-    _ogx_array_reader_setup_draw_start();
-    _ogx_array_reader_setup_draw(&glparamstate.vertex_array);
-    if (ne)
-        _ogx_array_reader_setup_draw(&glparamstate.normal_array);
-    if (color_provide)
-        _ogx_array_reader_setup_draw_color(&glparamstate.color_array,
-                                           color_provide == 2);
-    for (int tex = 0; tex < MAX_TEXTURE_UNITS; tex++) {
-        if (texen & (1 << tex)) {
-            _ogx_array_reader_setup_draw(&glparamstate.texcoord_array[tex]);
-        }
-    }
+    _ogx_arrays_setup_draw(ne, color_provide, texen);
 
     // Invalidate vertex data as may have been modified by the user
     GX_InvVtxCache();

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -2310,22 +2310,7 @@ static void draw_elements_general(DrawMode gxmode, int count, GLenum type,
     GX_Begin(gxmode.mode, GX_VTXFMT0, count + loop);
     for (int i = 0; i < count + loop; i++) {
         int index = read_index(indices, type, i % count);
-        _ogx_array_reader_process_element(&glparamstate.vertex_array, index);
-
-        if (ne) {
-            _ogx_array_reader_process_element(&glparamstate.normal_array, index);
-        }
-
-        if (color_provide) {
-            _ogx_array_reader_process_element(&glparamstate.color_array, index);
-        }
-
-        for (int tex = 0; tex < MAX_TEXTURE_UNITS; tex++) {
-            if (texen & (1 << tex)) {
-                _ogx_array_reader_process_element(
-                    &glparamstate.texcoord_array[tex], index);
-            }
-        }
+        _ogx_arrays_process_element(index);
     }
     GX_End();
 }
@@ -2487,22 +2472,7 @@ static void draw_arrays_general(DrawMode gxmode, int first, int count, int ne,
     int i;
     for (i = 0; i < count + loop; i++) {
         int j = i % count + first;
-        _ogx_array_reader_process_element(&glparamstate.vertex_array, j);
-
-        if (ne) {
-            _ogx_array_reader_process_element(&glparamstate.normal_array, j);
-        }
-
-        if (color_provide) {
-            _ogx_array_reader_process_element(&glparamstate.color_array, j);
-        }
-
-        for (int tex = 0; tex < MAX_TEXTURE_UNITS; tex++) {
-            if (texen & (1 << tex)) {
-                _ogx_array_reader_process_element(
-                    &glparamstate.texcoord_array[tex], j);
-            }
-        }
+        _ogx_arrays_process_element(j);
     }
     GX_End();
 }


### PR DESCRIPTION
Some application (like the Neverball game) specify the same array of positional coordinates to glTexCoordPointer(), and setup an appropriate texture matrix to transform them as needed. But GX only allows submitting up to two components of texture coordinates (s and t), and simply discarding the third component leads to incorrect rendering results.

The solution (which only works in the case the same array pointer is specified both as positional and texture coordinates -- a fully generic solution does not seem to be possible) is to setup the TEV so that texture coordinates are read from the positional array. This requires some refactoring of the array processing code.

Unlike the previous MR, these commits are all related (but can still be reviewed independently).