### PR TITLE
clip: fix disabling of clip planes

### DIFF
--- a/src/clip.c
+++ b/src/clip.c
@@ -170,7 +170,7 @@ void _ogx_clip_enabled(int plane)
 
 void _ogx_clip_disabled(int plane)
 {
-    glparamstate.stencil.enabled &= ~(1 << plane);
+    glparamstate.clip_plane_mask &= ~(1 << plane);
     glparamstate.dirty.bits.dirty_clip_planes = 1;
 }
 


### PR DESCRIPTION
Just a trivial copy-paste error, but don't ask me how much time I spent to debug it.