### PR TITLE
lighting: always take alpha from diffuse color

### DIFF
--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -2157,7 +2157,7 @@ bool _ogx_setup_render_stages()
         // STAGE 1: diffuse*vert_color + cprev -> cprev
         // In data: d: Raster Color a: CPREV
         GX_SetTevColorIn(GX_TEVSTAGE1, GX_CC_CPREV, GX_CC_ZERO, GX_CC_ZERO, GX_CC_RASC);
-        GX_SetTevAlphaIn(GX_TEVSTAGE1, GX_CA_ZERO, GX_CA_APREV, GX_CA_RASA, GX_CA_ZERO);
+        GX_SetTevAlphaIn(GX_TEVSTAGE1, GX_CA_RASA, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO);
         // Operation: Sum a + d
         GX_SetTevColorOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, raster_output);
         GX_SetTevAlphaOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, raster_output);


### PR DESCRIPTION
This is a fixup of commit 470b0272f37d877c379f768f0e51becfdd97eafc: the OpenGL spec says that the alpha value resulting from the raster operations is always the alpha value of the diffuse colour. We compute it in the second TEV stage, so modify the TEV operation to always use GX_CA_RASA without mixing it with any other value.