### PR TITLE
Call list and state improvements

### DIFF
--- a/src/accum.c
+++ b/src/accum.c
@@ -72,6 +72,7 @@ static void draw_screen(GXTexObj *texture, float value)
     GX_SetNumChans(1);
     GX_SetChanCtrl(GX_COLOR0A0, GX_DISABLE, GX_SRC_VTX, GX_SRC_VTX,
                    0, GX_DF_NONE, GX_AF_NONE);
+    glparamstate.dirty.bits.dirty_tev = 1;
 
     GX_SetCullMode(GX_CULL_NONE);
     glparamstate.dirty.bits.dirty_cull = 1;

--- a/src/arrays.cpp
+++ b/src/arrays.cpp
@@ -116,6 +116,9 @@ static TemplateSelectionInfo select_template(GLenum type,
         info.format.type = num_components == 1 ? GX_TEX_S : GX_TEX_ST;
         info.format.size = gl_type_to_gx_size(type);
         info.same_type = num_components <= 2;
+        /* The hardware does not support sending more than 2 texture
+         * coordinates */
+        if (num_components > 2) info.format.num_components = 2;
         break;
     case GX_VA_CLR0:
     case GX_VA_CLR1:

--- a/src/call_lists.c
+++ b/src/call_lists.c
@@ -103,7 +103,7 @@ typedef struct
         struct DrawGeometry {
             GLenum mode;
             uint16_t count;
-            struct client_state cs;
+            union client_state cs;
             u32 list_size;
             void *gxlist;
         } draw_geometry;
@@ -267,7 +267,7 @@ static void flat_draw_geometry(void *cb_data)
 
 static void run_draw_geometry(struct DrawGeometry *dg)
 {
-    struct client_state cs;
+    union client_state cs;
 
     /* Update the drawing mode on the list. This required peeping into
      * GX_Begin() code. */

--- a/src/call_lists.c
+++ b/src/call_lists.c
@@ -53,12 +53,6 @@ typedef struct
 {
     CommandType type;
     union {
-        struct GXDisplayList {
-            void *list;
-            u32 size;
-            struct client_state cs;
-        } gxlist;
-
         GLuint gllist; // glCallList
 
         GLenum cap; // glEnable, glDisable

--- a/src/clip.c
+++ b/src/clip.c
@@ -165,13 +165,13 @@ void _ogx_clip_setup_tev()
 void _ogx_clip_enabled(int plane)
 {
     glparamstate.clip_plane_mask |= 1 << plane;
-    glparamstate.dirty.bits.dirty_clip_planes = 1;
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void _ogx_clip_disabled(int plane)
 {
     glparamstate.clip_plane_mask &= ~(1 << plane);
-    glparamstate.dirty.bits.dirty_clip_planes = 1;
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void glClipPlane(GLenum plane, const GLdouble *equation)
@@ -192,4 +192,6 @@ void glClipPlane(GLenum plane, const GLdouble *equation)
     guMtx44Inverse(mv, mv_inverse);
     ClipPlane p0 = { equation[0], equation[1], equation[2], equation[3] };
     mtx44_multiply(p0, mv_inverse, *p);
+
+    glparamstate.dirty.bits.dirty_tev = 1;
 }

--- a/src/efb.c
+++ b/src/efb.c
@@ -88,6 +88,7 @@ void _ogx_efb_restore_texobj(GXTexObj *texobj)
     GX_SetNumChans(0);
     GX_SetTevOp(GX_TEVSTAGE0, GX_REPLACE);
     GX_SetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLORNULL);
+    glparamstate.dirty.bits.dirty_tev = 1;
 
     GX_SetCullMode(GX_CULL_NONE);
     glparamstate.dirty.bits.dirty_cull = 1;

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -2490,30 +2490,30 @@ static void draw_arrays_general(DrawMode gxmode, int first, int count)
 void glFrustum(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top,
                GLdouble near, GLdouble far)
 {
-    Mtx44 mt;
+    float mt[16];
     f32 tmp;
 
     tmp = 1.0f / (right - left);
-    mt[0][0] = (2 * near) * tmp;
-    mt[0][1] = 0.0f;
-    mt[0][2] = (right + left) * tmp;
-    mt[0][3] = 0.0f;
+    mt[0] = (2 * near) * tmp;
+    mt[4] = 0.0f;
+    mt[8] = (right + left) * tmp;
+    mt[12] = 0.0f;
     tmp = 1.0f / (top - bottom);
-    mt[1][0] = 0.0f;
-    mt[1][1] = (2 * near) * tmp;
-    mt[1][2] = (top + bottom) * tmp;
-    mt[1][3] = 0.0f;
+    mt[1] = 0.0f;
+    mt[5] = (2 * near) * tmp;
+    mt[9] = (top + bottom) * tmp;
+    mt[13] = 0.0f;
     tmp = 1.0f / (far - near);
-    mt[2][0] = 0.0f;
-    mt[2][1] = 0.0f;
-    mt[2][2] = -(far + near) * tmp;
-    mt[2][3] = -2.0 * (far * near) * tmp;
-    mt[3][0] = 0.0f;
-    mt[3][1] = 0.0f;
-    mt[3][2] = -1.0f;
-    mt[3][3] = 0.0f;
+    mt[2] = 0.0f;
+    mt[6] = 0.0f;
+    mt[10] = -(far + near) * tmp;
+    mt[14] = -2.0 * (far * near) * tmp;
+    mt[3] = 0.0f;
+    mt[7] = 0.0f;
+    mt[11] = -1.0f;
+    mt[15] = 0.0f;
 
-    glMultMatrixf((float *)mt);
+    glMultMatrixf(mt);
 }
 
 void glOrtho(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble near_val, GLdouble far_val)

--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -300,11 +300,7 @@ void ogx_initialize()
     glparamstate.imm_mode.current_numverts = 0;
     glparamstate.imm_mode.in_gl_begin = 0;
 
-    glparamstate.cs.vertex_enabled = 0; // DisableClientState on everything
-    glparamstate.cs.normal_enabled = 0;
-    glparamstate.cs.texcoord_enabled = 0;
-    glparamstate.cs.index_enabled = 0;
-    glparamstate.cs.color_enabled = 0;
+    glparamstate.cs.as_int = 0; // DisableClientState on everything
 
     glparamstate.texture_enabled = 0;
     glparamstate.pack_alignment = 4;
@@ -949,7 +945,7 @@ void glBegin(GLenum mode)
 
 void glEnd()
 {
-    struct client_state cs_backup = glparamstate.cs;
+    union client_state cs_backup = glparamstate.cs;
     VertexData *base = glparamstate.imm_mode.current_vertices;
     int stride = sizeof(VertexData);
     for (int i = 0; i < MAX_TEXTURE_UNITS; i++) {

--- a/src/raster.cpp
+++ b/src/raster.cpp
@@ -227,6 +227,7 @@ static void draw_raster_texture(GXTexObj *texture, int width, int height,
     GX_SetNumTexGens(1);
     GX_SetNumTevStages(1);
     GX_SetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR0A0);
+    glparamstate.dirty.bits.dirty_tev = 1;
 
     GX_SetCullMode(GX_CULL_NONE);
     glparamstate.dirty.bits.dirty_cull = 1;

--- a/src/selection.c
+++ b/src/selection.c
@@ -103,6 +103,7 @@ static void restore_z_buffer()
     GX_SetNumChans(0);
     GX_SetTevOp(GX_TEVSTAGE0, GX_REPLACE);
     GX_SetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLORNULL);
+    glparamstate.dirty.bits.dirty_tev = 1;
 
     GX_SetCullMode(GX_CULL_NONE);
     glparamstate.dirty.bits.dirty_cull = 1;

--- a/src/state.h
+++ b/src/state.h
@@ -240,11 +240,8 @@ typedef struct glparams_
             unsigned dirty_clearz : 1;
             unsigned dirty_color_update : 1;
             unsigned dirty_matrices : 1;
-            unsigned dirty_lighting : 1;
-            unsigned dirty_material : 1;
-            unsigned dirty_clip_planes : 1;
+            unsigned dirty_tev : 1;
             unsigned dirty_cull : 1;
-            unsigned dirty_stencil : 1;
             unsigned dirty_fog : 1;
         } bits;
         unsigned int all;

--- a/src/state.h
+++ b/src/state.h
@@ -181,14 +181,17 @@ typedef struct glparams_
     void *index_array;
     OgxArrayReader vertex_array, normal_array, color_array;
     OgxArrayReader texcoord_array[MAX_TEXTURE_UNITS];
-    struct client_state
+    union client_state
     {
-        unsigned vertex_enabled : 1;
-        unsigned normal_enabled : 1;
-        unsigned index_enabled : 1;
-        unsigned color_enabled : 1;
-        unsigned texcoord_enabled : MAX_TEXTURE_UNITS;
-        char active_texture;
+        struct {
+            unsigned vertex_enabled : 1;
+            unsigned normal_enabled : 1;
+            unsigned index_enabled : 1;
+            unsigned color_enabled : 1;
+            unsigned texcoord_enabled : MAX_TEXTURE_UNITS;
+            char active_texture;
+        };
+        uint32_t as_int;
     } cs;
 
     unsigned texture_enabled : MAX_TEXTURE_UNITS;

--- a/src/state.h
+++ b/src/state.h
@@ -245,6 +245,7 @@ typedef struct glparams_
             unsigned dirty_clip_planes : 1;
             unsigned dirty_cull : 1;
             unsigned dirty_stencil : 1;
+            unsigned dirty_fog : 1;
         } bits;
         unsigned int all;
     } dirty;

--- a/src/stencil.c
+++ b/src/stencil.c
@@ -545,13 +545,13 @@ void _ogx_stencil_draw(OgxStencilDrawCallback callback, void *cb_data)
 void _ogx_stencil_enabled()
 {
     glparamstate.stencil.enabled = 1;
-    glparamstate.dirty.bits.dirty_stencil = 1;
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void _ogx_stencil_disabled()
 {
     glparamstate.stencil.enabled = 0;
-    glparamstate.dirty.bits.dirty_stencil = 1;
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void _ogx_stencil_update()
@@ -659,14 +659,17 @@ void glStencilFunc(GLenum func, GLint ref, GLuint mask)
         glparamstate.stencil.func = new_func;
         if (tev_stage_needed(new_type) && new_type != old_type)
             s_stencil_texture_needs_update = true;
+        glparamstate.dirty.bits.dirty_tev = 1;
     }
     if (new_ref != glparamstate.stencil.ref) {
         glparamstate.stencil.ref = new_ref;
         s_stencil_texture_needs_update = true;
+        glparamstate.dirty.bits.dirty_tev = 1;
     }
     if (new_mask != glparamstate.stencil.mask) {
         glparamstate.stencil.mask = new_mask;
         s_stencil_texture_needs_update = true;
+        glparamstate.dirty.bits.dirty_tev = 1;
     }
 }
 

--- a/src/texture.c
+++ b/src/texture.c
@@ -212,6 +212,7 @@ void glTexGeni(GLenum coord, GLenum pname, GLint param)
         tu->gen_mode = param;
         break;
     }
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void glTexGenfv(GLenum coord, GLenum pname, const GLfloat *params)
@@ -221,7 +222,7 @@ void glTexGenfv(GLenum coord, GLenum pname, const GLfloat *params)
     switch (pname) {
     case GL_TEXTURE_GEN_MODE:
         glTexGeni(coord, pname, params[0]);
-        break;
+        return;
     case GL_EYE_PLANE:
         if (coord == GL_S) {
             floatcpy(tu->texture_eye_plane_s, params, 4);
@@ -237,6 +238,7 @@ void glTexGenfv(GLenum coord, GLenum pname, const GLfloat *params)
         }
         break;
     }
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void glTexEnvf(GLenum target, GLenum pname, GLfloat param)
@@ -296,6 +298,7 @@ void glTexEnvi(GLenum target, GLenum pname, GLint param)
         tu->mode = param;
         break;
     }
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void glTexEnvfv(GLenum target, GLenum pname, const GLfloat *params)
@@ -307,8 +310,9 @@ void glTexEnvfv(GLenum target, GLenum pname, const GLfloat *params)
         break;
     default:
         glTexEnvf(target, pname, params[0]);
-        break;
+        return;
     }
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void glTexEnviv(GLenum target, GLenum pname, const GLint *params)
@@ -394,6 +398,7 @@ static void update_texture(const void *data, int level, GLenum format, GLenum ty
     GX_InitTexObjLOD(obj, ti->min_filter, ti->mag_filter,
                      ti->minlevel, ti->maxlevel, 0, GX_ENABLE, GX_ENABLE, GX_ANISO_1);
     GX_InitTexObjUserData(obj, ti->ud.ptr);
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void glTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height,
@@ -519,6 +524,8 @@ void glBindTexture(GLenum target, GLuint texture)
      * defined yet. We do this when setting up the texturing TEV stage. */
     int unit = glparamstate.active_texture;
     glparamstate.texture_unit[unit].glcurtex = texture;
+
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void glTexImage3D(GLenum target, GLint level, GLint internalFormat,

--- a/src/utils.h
+++ b/src/utils.h
@@ -275,10 +275,12 @@ static inline void gl_matrix_to_gx(const GLfloat *source, Mtx mv)
     float w = source[15];
     if (w != 1.0 && w != 0.0) {
         for (int i = 0; i < 16; i++) {
+            if (i % 4 == 3) continue;
             mv[i%4][i/4] = source[i] / w;
         }
     } else {
         for (int i = 0; i < 16; i++) {
+            if (i % 4 == 3) continue;
             mv[i%4][i/4] = source[i];
         }
     }

--- a/src/vertex.cpp
+++ b/src/vertex.cpp
@@ -77,6 +77,7 @@ void set_current_color(T red, T green, T blue, T alpha = full_color<T>())
     }
 
     floatcpy(glparamstate.imm_mode.current_color, c, 4);
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 static inline void set_current_tex_unit_coords(int unit, float s, float t = 0)
@@ -302,6 +303,7 @@ void glNormal3fv(const GLfloat *v)
         HANDLE_CALL_LIST(NORMAL, v);
     }
     floatcpy(glparamstate.imm_mode.current_normal, v, 3);
+    glparamstate.dirty.bits.dirty_tev = 1;
 }
 
 void glNormal3iv(const GLint *v)


### PR DESCRIPTION
crack-attack performance went down a lot when we introduced support for clipping, since that's an extra TEV stage and it involves some matrix multiplications. On the other hand, we don't have to setup the TEV stages if no parameters affecting it have been changed.

This MR fixes a couple of regressions, cleans up the fogging setup and adds a "dirty bit" to decide when the TEV stages must be rebuilt.

To be merged after https://github.com/devkitPro/opengx/pull/88