### PR TITLE
getters: fix glGetBoolean for GL_UNPACK_LSB_FIRST and GL_PACK_SWAP_BYTES

### DIFF
--- a/src/getters.c
+++ b/src/getters.c
@@ -179,7 +179,7 @@ void glGetBooleanv(GLenum pname, GLboolean *params)
         return;
     case GL_PACK_SWAP_BYTES:
         *params = glparamstate.pack_swap_bytes;
-        break;
+        return;
     case GL_RGBA_MODE:
         *params = GL_TRUE;
         return;
@@ -188,7 +188,7 @@ void glGetBooleanv(GLenum pname, GLboolean *params)
         return;
     case GL_UNPACK_LSB_FIRST:
         *params = glparamstate.unpack_lsb_first;
-        break;
+        return;
     case GL_UNPACK_SWAP_BYTES:
         *params = glparamstate.unpack_swap_bytes;
         return;


### PR DESCRIPTION
The logic for putting return or break in the getter code is the following: if the current getter can lookup the value, it should return immediately after storing it into the output variable; otherwise, we should "break" from the switch, and then there should be a fallback code to delegate the operation to a different getter.

This fixes gluBuild2DMipmaps(), which calls

    glGetIntegerv(GL_UNPACK_LSB_FIRST, &psm->unpack_lsb_first);

and was broken by commit 94b3aab94b9173a9e0ee7f2b4af119b43215348e.