### PR TITLE
textures: fix texture size on uninitialized textures

### DIFF
--- a/src/texture.c
+++ b/src/texture.c
@@ -142,6 +142,9 @@ static void texture_get_info(const GXTexObj *obj, TextureInfo *info)
                     &info->mipmap);
     if (info->texels) {
         info->texels = MEM_PHYSICAL_TO_K0(info->texels);
+    } else {
+        /* Ensure size is 0 if there's no texture  */
+        info->width = info->height = 0;
     }
 
     float minlevel, maxlevel;


### PR DESCRIPTION
GX_TexObjGetAll() returns a size of 1024x1024 if called on a 0-initialized object, due to how texture size is internally stored.

Workaround this issue by explicitly setting width and height to 0 if we see that the texel pointer is NULL.