### PR TITLE
Prevent Widescreen from Breaking Applications

### DIFF
--- a/src/gc_gl.c
+++ b/src/gc_gl.c
@@ -1015,6 +1015,7 @@ void glEnd()
 
 void glViewport(GLint x, GLint y, GLsizei width, GLsizei height)
 {
+   if (width > 640) width = 640;
     glparamstate.viewport[0] = x;
     glparamstate.viewport[1] = y;
     glparamstate.viewport[2] = width;
@@ -1031,6 +1032,7 @@ void glViewport(GLint x, GLint y, GLsizei width, GLsizei height)
 
 void glScissor(GLint x, GLint y, GLsizei width, GLsizei height)
 {
+    if (width > 640) width = 640;
     glparamstate.scissor[0] = x;
     glparamstate.scissor[1] = y;
     glparamstate.scissor[2] = width;


### PR DESCRIPTION
Fix to prevent apps from dying when/if https://github.com/devkitPro/SDL/pull/91 gets merged, as it reports the screen width as 854 so apps know it's widescreen, but the viewport and scissor can't be over 640.

Just making sure developers don't have their app break without knowing why :)